### PR TITLE
delay ZkTrieLogObserver construction until after cli param parsing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-releaseVersion=0.1.0-SNAPSHOT
+releaseVersion=0.2.0-SNAPSHOT
 besuVersion=23.4.1-SNAPSHOT

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogObserver.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogObserver.java
@@ -37,8 +37,8 @@ public class ZkTrieLogObserver
 
   private static final Logger LOG = LoggerFactory.getLogger(ZkTrieLogObserver.class);
   // todo: get from config
-  private String shomeiHttpHost = "localhost";
-  private int shomeiHttpPort = 8888;
+  private final String shomeiHttpHost;
+  private final int shomeiHttpPort;
   private boolean isSyncing;
   private static long timeSinceLastLog = System.currentTimeMillis();
 
@@ -50,6 +50,7 @@ public class ZkTrieLogObserver
     this.webClient = WebClient.create(vertx, options);
     this.shomeiHttpHost = shomeiHttpHost;
     this.shomeiHttpPort = shomeiHttpPort;
+    LOG.info("shomei http host:port {}:{}", this.shomeiHttpHost, this.shomeiHttpPort);
 
     // TODO: wire up the SyncStatusListener via plugin, until then hack:
 

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogService.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogService.java
@@ -23,26 +23,28 @@ import org.hyperledger.besu.plugin.services.trielogs.TrieLogFactory;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLogProvider;
 
 public class ZkTrieLogService implements TrieLogService {
-  private static AtomicReference<ZkTrieLogService> singleton = new AtomicReference<>();
+  private static ZkTrieLogService singleton = new ZkTrieLogService();
 
-  ZkTrieLogService() {
-    observer =
-        new ZkTrieLogObserver(
-            ShomeiCliOptions.INSTANCE.shomeiHttpHost, ShomeiCliOptions.INSTANCE.shomeiHttpPort);
-  }
+  ZkTrieLogService() {}
 
   public static ZkTrieLogService getInstance() {
-    singleton.compareAndSet(null, new ZkTrieLogService());
-    return singleton.get();
+    return singleton;
   }
 
   // TODO: configure:
-  private final ZkTrieLogObserver observer;
+  private final AtomicReference<ZkTrieLogObserver> observer = new AtomicReference<>();
   private TrieLogProvider trieLogProvider = null;
 
   @Override
   public List<TrieLogEvent.TrieLogObserver> getObservers() {
-    return List.of(observer);
+    // initialize observer late so we are assured we have gotten pico cli params from besu
+    if (observer.get() == null) {
+      observer.compareAndSet(
+          null,
+          new ZkTrieLogObserver(
+              ShomeiCliOptions.INSTANCE.shomeiHttpHost, ShomeiCliOptions.INSTANCE.shomeiHttpPort));
+    }
+    return List.of(observer.get());
   }
 
   @Override


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
Fix a regression where ZkTrieLogObserver was being constructed with default parameters.  PR delays the construction until Observer is first fetched.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
