### PR TITLE
rename plugin TrieLogLayer class 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,16 +14,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'adopt'
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -52,16 +52,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: 17
           distribution: 'adopt'
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -72,7 +72,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Download workspace
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: workspace
 
@@ -80,7 +80,7 @@ jobs:
         run: ./gradlew --no-daemon build
 
       - name: Store distribution artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: distributions
           path: build/distributions

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import groovy.transform.Memoized
 
 /*
  * Copyright ConsenSys 2023
- *
+ *]
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
  *

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-releaseVersion=0.2.0-SNAPSHOT
+releaseVersion=0.2.1-SNAPSHOT
 besuVersion=23.4.1-SNAPSHOT

--- a/src/main/java/net/consensys/shomei/trielog/PluginTrieLogLayer.java
+++ b/src/main/java/net/consensys/shomei/trielog/PluginTrieLogLayer.java
@@ -37,7 +37,7 @@ import org.hyperledger.besu.plugin.services.trielogs.TrieLog;
  * trie changes as well.
  */
 @SuppressWarnings("unchecked")
-public record TrieLogLayer(
+public record PluginTrieLogLayer(
     Hash blockHash,
     Optional<Long> blockNumber,
     Map<Address, TrieLog.LogTuple<AccountValue>> accounts,
@@ -46,8 +46,8 @@ public record TrieLogLayer(
     boolean frozen)
     implements TrieLog {
 
-  /** Creates a new TrieLogLayer with blockhash and empty maps to deserialize into. */
-  public TrieLogLayer(final Hash blockHash) {
+  /** Creates a new PluginTrieLogLayer with blockhash and empty maps to deserialize into. */
+  public PluginTrieLogLayer(final Hash blockHash) {
     this(blockHash, Optional.empty(), new HashMap<>(), new HashMap<>(), new HashMap<>(), true);
   }
 
@@ -186,7 +186,7 @@ public record TrieLogLayer(
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    TrieLogLayer that = (TrieLogLayer) o;
+    PluginTrieLogLayer that = (PluginTrieLogLayer) o;
     return new EqualsBuilder()
         .append(frozen, that.frozen)
         .append(blockHash, that.blockHash)

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -56,7 +56,7 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     LOG.info(
         "creating ZkTrieLog for block {}:{}", blockHeader.getNumber(), blockHeader.getBlockHash());
 
-    return new TrieLogLayer(
+    return new PluginTrieLogLayer(
         blockHeader.getBlockHash(),
         Optional.of(blockHeader.getNumber()),
         (Map<Address, LogTuple<AccountValue>>) accountsToUpdate,
@@ -134,11 +134,11 @@ public class ZkTrieLogFactory implements TrieLogFactory {
   }
 
   @Override
-  public TrieLogLayer deserialize(final byte[] bytes) {
+  public PluginTrieLogLayer deserialize(final byte[] bytes) {
     return readFrom(new BytesValueRLPInput(Bytes.wrap(bytes), false));
   }
 
-  public static TrieLogLayer readFrom(final RLPInput input) {
+  public static PluginTrieLogLayer readFrom(final RLPInput input) {
     Map<Address, LogTuple<AccountValue>> accounts = new HashMap<>();
     Map<Address, LogTuple<Bytes>> code = new HashMap<>();
     Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>> storage = new HashMap<>();
@@ -208,7 +208,7 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     }
     input.leaveListLenient();
 
-    return new TrieLogLayer(blockHash, blockNumber, accounts, code, storage, true);
+    return new PluginTrieLogLayer(blockHash, blockNumber, accounts, code, storage, true);
   }
 
   protected static <T> T nullOrValue(final RLPInput input, final Function<RLPInput, T> reader) {

--- a/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogsTests.java
+++ b/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogsTests.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.when;
 
 import net.consensys.shomei.rpc.methods.ShomeiGetTrieLog;
 import net.consensys.shomei.rpc.methods.ShomeiGetTrieLogsByRange;
-import net.consensys.shomei.trielog.TrieLogLayer;
+import net.consensys.shomei.trielog.PluginTrieLogLayer;
 import net.consensys.shomei.trielog.ZkTrieLogService;
 
 import java.util.List;
@@ -51,8 +51,8 @@ public class GetShomeiTrieLogsTests {
   ZkTrieLogService trieLogService = spy(ZkTrieLogService.getInstance());
   @Mock TrieLogProvider mockProvider;
 
-  TrieLogLayer mockLayer =
-      new TrieLogLayer(Hash.ZERO, Optional.of(0L), Map.of(), Map.of(), Map.of(), true);
+  PluginTrieLogLayer mockLayer =
+      new PluginTrieLogLayer(Hash.ZERO, Optional.of(0L), Map.of(), Map.of(), Map.of(), true);
 
   MockJsonRpcHttpVerticle verticle;
   WebClient client;

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 public class ZkTrieLogFactoryTests {
 
   final Address accountFixture = Address.fromHexString("0xdeadbeef");
-  final TrieLogLayer trieLogFixture = new TrieLogLayer(Hash.ZERO);
+  final PluginTrieLogLayer trieLogFixture = new PluginTrieLogLayer(Hash.ZERO);
 
   @BeforeEach
   public void setup() {

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogObserverTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogObserverTests.java
@@ -49,8 +49,8 @@ public class ZkTrieLogObserverTests {
       "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"accepted\"}";
 
   private ZkTrieLogFactory zkTrieLogFactory = new ZkTrieLogFactory();
-  private TrieLogLayer trieLogFixture =
-      new TrieLogLayer(
+  private PluginTrieLogLayer trieLogFixture =
+      new PluginTrieLogLayer(
           Hash.ZERO,
           Optional.of(1337L),
           Map.of(
@@ -167,7 +167,7 @@ public class ZkTrieLogObserverTests {
         });
   }
 
-  record MockTrieLogEvent(TrieLogLayer trieLog) implements TrieLogEvent {
+  record MockTrieLogEvent(PluginTrieLogLayer trieLog) implements TrieLogEvent {
     @Override
     public Type getType() {
       return Type.ADDED;


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
when using the plugin artifact in shomei, there is a class name conflict with net.consensys.shomei.TrieLogLayer. This PR renames TrieLogLayer to PluginTrieLogLayer to avoid the conflict, as well as bumps the release revision to 0.2.1

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
