### PR TITLE
Add filtering comparison mode

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-releaseVersion=0.5.2-SNAPSHOT
+releaseVersion=0.6.0-SNAPSHOT
 besuVersion=25.4.1-linea1
 arithmetizationVersion=beta-v2.1-rc16

--- a/src/main/java/net/consensys/shomei/cli/ShomeiCliOptions.java
+++ b/src/main/java/net/consensys/shomei/cli/ShomeiCliOptions.java
@@ -81,7 +81,8 @@ public class ShomeiCliOptions {
     MISMATCH_LOGGING(1),
     HUB_TO_ACCUMULATOR(2),
     ACCUMULATOR_TO_HUB(4),
-    DECORATE_FROM_HUB(8);
+    DECORATE_FROM_HUB(8),
+    FILTER_FROM_HUB(16);
 
     private final int bit;
 
@@ -135,6 +136,7 @@ public class ShomeiCliOptions {
         "2 = compare HUB→ACCUMULATOR",
         "4 = compare ACCUMULATOR→HUB",
         "8 = DECORATE ACCUMULATOR FROM HUB.",
+        "16 = FILTER ACCUMULATOR BY HUB.",
         "Add values (e.g., 3 = LOGGING + HUB→ACC, default no comparison enabled)."
       })
   public int zkTraceComparisonMask = 0;

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -15,6 +15,7 @@
 package net.consensys.shomei.trielog;
 
 import static net.consensys.shomei.cli.ShomeiCliOptions.ZkTraceComparisonFeature.DECORATE_FROM_HUB;
+import static net.consensys.shomei.cli.ShomeiCliOptions.ZkTraceComparisonFeature.FILTER_FROM_HUB;
 import static net.consensys.shomei.cli.ShomeiCliOptions.ZkTraceComparisonFeature.isEnabled;
 
 import net.consensys.shomei.context.ShomeiContext;
@@ -28,7 +29,9 @@ import java.util.TreeSet;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -81,8 +84,15 @@ public class ZkTrieLogFactory implements TrieLogFactory {
           ctx.getBlockImportTraceProvider().compareWithTrace(blockHeader, accumulator);
       if (isEnabled(comparisonFeatureMask.get(), DECORATE_FROM_HUB)) {
         accountsToUpdate =
-            decorateAccounts(accountsToUpdate, hubSeenDiff.adressesDiff(), accumulator);
-        storageToUpdate = decorateStorage(storageToUpdate, hubSeenDiff.storageDiff(), accumulator);
+            decorateAccounts(
+                accountsToUpdate, hubSeenDiff.foundInHub().adressesDiff(), accumulator);
+        storageToUpdate =
+            decorateStorage(storageToUpdate, hubSeenDiff.foundInHub().storageDiff(), accumulator);
+      }
+      if (isEnabled(comparisonFeatureMask.get(), FILTER_FROM_HUB)) {
+        accountsToUpdate =
+            filterAccounts(accountsToUpdate, hubSeenDiff.notFoundInHub().adressesDiff());
+        storageToUpdate = filterStorage(storageToUpdate, hubSeenDiff.notFoundInHub().storageDiff());
       }
     }
 
@@ -100,7 +110,7 @@ public class ZkTrieLogFactory implements TrieLogFactory {
 
   /* safe map decorator, in case the map we are provided is immutable */
   @SuppressWarnings("unchecked")
-  Map<Address, LogTuple<AccountValue>> decorateAccounts(
+  static Map<Address, LogTuple<AccountValue>> decorateAccounts(
       Map<Address, ? extends LogTuple<? extends AccountValue>> accountsToUpdate,
       Set<Address> hubSeenAccounts,
       final TrieLogAccumulator accumulator) {
@@ -124,9 +134,18 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     return decorated;
   }
 
+  @VisibleForTesting
+  static Map<Address, ? extends LogTuple<? extends AccountValue>> filterAccounts(
+      Map<Address, ? extends LogTuple<? extends AccountValue>> accountsToUpdate,
+      Set<Address> hubNotSeenAccounts) {
+    return accountsToUpdate.entrySet().stream()
+        .filter(accumulatorEntry -> !hubNotSeenAccounts.contains(accumulatorEntry.getKey()))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
   /* safe map decorator which also solves challenges with generics */
   @SuppressWarnings("unchecked")
-  Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>> decorateStorage(
+  static Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>> decorateStorage(
       Map<Address, ? extends Map<StorageSlotKey, ? extends TrieLog.LogTuple<UInt256>>>
           storageToUpdate,
       Map<Address, Set<Bytes32>> hubSeenStorage,
@@ -164,6 +183,40 @@ public class ZkTrieLogFactory implements TrieLogFactory {
       LOG.warn("ignoring incompatible accumulator for storage {}", accumulator.getClass());
     }
     return result;
+  }
+
+  @VisibleForTesting
+  static Map<Address, Map<StorageSlotKey, ? extends LogTuple<UInt256>>> filterStorage(
+      Map<Address, ? extends Map<StorageSlotKey, ? extends TrieLog.LogTuple<UInt256>>>
+          storageToUpdate,
+      Map<Address, Set<Bytes32>> hubNotSeenStorage) {
+
+    return storageToUpdate.entrySet().stream()
+        .map(
+            entry -> {
+              Address address = entry.getKey();
+              Set<Bytes32> notSeenSlots = hubNotSeenStorage.get(address);
+              if (notSeenSlots == null) {
+                return entry;
+              }
+
+              // Filter the inner storage map by presence in seenSlots
+              Map<StorageSlotKey, LogTuple<UInt256>> filteredSlots =
+                  entry.getValue().entrySet().stream()
+                      .filter(
+                          slotEntry ->
+                              slotEntry
+                                  .getKey()
+                                  .getSlotKey()
+                                  .map(UInt256::toBytes)
+                                  .filter(notSeenSlots::contains)
+                                  .isEmpty())
+                      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+              return Map.entry(address, filteredSlots);
+            })
+        .filter(e -> !e.getValue().isEmpty())
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   @Override

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -233,7 +233,7 @@ public class ZkTrieLogFactoryTests {
             Set.of(mockAddress),
             Map.of(
                 mockAddress, Set.of(UInt256.ZERO, UInt256.ONE),
-                mockAddress2, Set.of(UInt256.ZERO)));
+                mockAddress2, Set.of(UInt256.ZERO, UInt256.MAX_VALUE)));
     var mockDiffTuple =
         new ZkBlockImportTracerProvider.HubDiffTuple(
             new HubSeenDiff(Collections.emptySet(), Collections.emptyMap()), mockDiff);
@@ -260,7 +260,9 @@ public class ZkTrieLogFactoryTests {
         mockAddress2,
         Map.of(
             new StorageSlotKey(UInt256.ZERO), new PathBasedValue<>(UInt256.ZERO, UInt256.ZERO),
-            new StorageSlotKey(UInt256.ONE), new PathBasedValue<>(UInt256.ZERO, UInt256.ONE)));
+            new StorageSlotKey(UInt256.ONE), new PathBasedValue<>(UInt256.ZERO, UInt256.ONE),
+            new StorageSlotKey(UInt256.MAX_VALUE),
+                new PathBasedValue<>(UInt256.ZERO, UInt256.ONE)));
     mockStorageMap.put(
         mockAddress3,
         Map.of(new StorageSlotKey(UInt256.ZERO), new PathBasedValue<>(UInt256.ZERO, UInt256.ZERO)));
@@ -286,8 +288,10 @@ public class ZkTrieLogFactoryTests {
     // assert we partially filtered mockAddress2 storage
     var address2StorageChanges = trielog.getStorageChanges().get(mockAddress2);
     assertNotNull(address2StorageChanges);
-    assertThat(address2StorageChanges.size()).isEqualTo(1);
+    assertThat(address2StorageChanges.size()).isEqualTo(2);
     assertTrue(address2StorageChanges.containsKey(new StorageSlotKey(UInt256.ONE)));
+    // assert we refused to filter a changed slot value:
+    assertTrue(address2StorageChanges.containsKey(new StorageSlotKey(UInt256.MAX_VALUE)));
 
     // assert we did not filter mockAddress3 storage
     var address3StorageChanges = trielog.getStorageChanges().get(mockAddress3);

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -15,6 +15,10 @@
 package net.consensys.shomei.trielog;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
@@ -26,12 +30,14 @@ import net.consensys.shomei.blocktracing.ZkBlockImportTracerProvider.HubSeenDiff
 import net.consensys.shomei.cli.ShomeiCliOptions;
 import net.consensys.shomei.context.TestShomeiContext;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.hyperledger.besu.datatypes.AccountValue;
 import org.hyperledger.besu.datatypes.Address;
@@ -43,6 +49,7 @@ import org.hyperledger.besu.ethereum.trie.pathbased.common.PathBasedValue;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.accumulator.PathBasedWorldStateUpdateAccumulator;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLog;
+import org.hyperledger.besu.plugin.services.trielogs.TrieLog.LogTuple;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLogFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -139,11 +146,16 @@ public class ZkTrieLogFactoryTests {
         new HubSeenDiff(
             Set.of(mockAddress, mockAddress2),
             Map.of(mockAddress, Set.of(UInt256.ZERO, UInt256.ONE)));
-    doAnswer(__ -> mockDiff).when(mockTraceProvider).compareWithTrace(any(), any());
 
     // mock test options to enable tracing
     ShomeiCliOptions testOpts = new ShomeiCliOptions();
+
+    // everything except filtering
     testOpts.zkTraceComparisonMask = 15;
+
+    // use same diff for found and missing to assert we are not filtering
+    var mockDiffTuple = new ZkBlockImportTracerProvider.HubDiffTuple(mockDiff, mockDiff);
+    doAnswer(__ -> mockDiffTuple).when(mockTraceProvider).compareWithTrace(any(), any());
 
     // configure our test context
     testCtx.setCliOptions(testOpts).setBlockImportTraceProvider(mockTraceProvider);
@@ -169,7 +181,7 @@ public class ZkTrieLogFactoryTests {
             Hash.EMPTY_TRIE_HASH,
             Hash.ZERO,
             false);
-    ;
+
     var mockAccountMap = new HashMap<Address, PathBasedValue<AccountValue>>();
     mockAccountMap.put(mockAddress2, new PathBasedValue<>(account2, account2, false));
 
@@ -207,5 +219,162 @@ public class ZkTrieLogFactoryTests {
     assertThat(hubAddressStorageChanges.containsKey(zeroKey)).isTrue();
     var oneKey = new StorageSlotKey(UInt256.ONE);
     assertThat(hubAddressStorageChanges.containsKey(oneKey)).isTrue();
+  }
+
+  @Test
+  public void assertHubSeenFiltersTrieLog() {
+    // mock trace provider
+    var mockTraceProvider = mock(ZkBlockImportTracerProvider.class);
+    var mockAddress = Address.fromHexString("0xdeadbeef");
+    var mockAddress2 = Address.fromHexString("0xc0ffee");
+    var mockAddress3 = Address.fromHexString("0x1337");
+    var mockDiff =
+        new HubSeenDiff(
+            Set.of(mockAddress),
+            Map.of(
+                mockAddress, Set.of(UInt256.ZERO, UInt256.ONE),
+                mockAddress2, Set.of(UInt256.ZERO)));
+    var mockDiffTuple =
+        new ZkBlockImportTracerProvider.HubDiffTuple(
+            new HubSeenDiff(Collections.emptySet(), Collections.emptyMap()), mockDiff);
+    doAnswer(__ -> mockDiffTuple).when(mockTraceProvider).compareWithTrace(any(), any());
+
+    // mock test options to enable tracing
+    ShomeiCliOptions testOpts = new ShomeiCliOptions();
+    // only enable filtering
+    testOpts.zkTraceComparisonMask = 16;
+
+    // configure our test context
+    testCtx.setCliOptions(testOpts).setBlockImportTraceProvider(mockTraceProvider);
+
+    var mockAccumulator = mock(PathBasedWorldStateUpdateAccumulator.class, RETURNS_DEEP_STUBS);
+    var mockAccountMap = new HashMap<Address, PathBasedValue<AccountValue>>();
+    var dummyAcctVal = new ZkAccountValue(0, null, null, null);
+    mockAccountMap.put(mockAddress, new PathBasedValue<>(dummyAcctVal, dummyAcctVal));
+    mockAccountMap.put(mockAddress2, new PathBasedValue<>(dummyAcctVal, dummyAcctVal));
+    var mockStorageMap = new HashMap<Address, Map<StorageSlotKey, PathBasedValue<UInt256>>>();
+    mockStorageMap.put(
+        mockAddress,
+        Map.of(new StorageSlotKey(UInt256.ZERO), new PathBasedValue<>(UInt256.ONE, UInt256.ONE)));
+    mockStorageMap.put(
+        mockAddress2,
+        Map.of(
+            new StorageSlotKey(UInt256.ZERO), new PathBasedValue<>(UInt256.ZERO, UInt256.ZERO),
+            new StorageSlotKey(UInt256.ONE), new PathBasedValue<>(UInt256.ZERO, UInt256.ONE)));
+    mockStorageMap.put(
+        mockAddress3,
+        Map.of(new StorageSlotKey(UInt256.ZERO), new PathBasedValue<>(UInt256.ZERO, UInt256.ZERO)));
+    doAnswer(__ -> mockAccountMap).when(mockAccumulator).getAccountsToUpdate();
+    doAnswer(__ -> mockStorageMap).when(mockAccumulator).getStorageToUpdate();
+
+    // mock block header
+    var mockHeader = mock(BlockHeader.class, RETURNS_DEEP_STUBS);
+
+    // create factor class under test:
+    var factory = new ZkTrieLogFactory(testCtx);
+
+    // generate the trielog
+    var trielog = factory.create(mockAccumulator, mockHeader);
+
+    // assert we filtered out mockAddress, and not mockAddress2
+    assertThat(trielog.getAccountChanges().containsKey(mockAddress)).isFalse();
+    assertThat(trielog.getAccountChanges().containsKey(mockAddress2)).isTrue();
+
+    // assert we filtered out all mockAddress storage:
+    assertThat(trielog.getStorageChanges().containsKey(mockAddress)).isFalse();
+
+    // assert we partially filtered mockAddress2 storage
+    var address2StorageChanges = trielog.getStorageChanges().get(mockAddress2);
+    assertNotNull(address2StorageChanges);
+    assertThat(address2StorageChanges.size()).isEqualTo(1);
+    assertTrue(address2StorageChanges.containsKey(new StorageSlotKey(UInt256.ONE)));
+
+    // assert we did not filter mockAddress3 storage
+    var address3StorageChanges = trielog.getStorageChanges().get(mockAddress3);
+    assertNotNull(address3StorageChanges);
+    assertThat(address3StorageChanges.size()).isEqualTo(1);
+    assertTrue(address3StorageChanges.containsKey(new StorageSlotKey(UInt256.ZERO)));
+  }
+
+  @Test
+  void testFilterAccounts() {
+    Address address1 = Address.fromHexString("0xdead");
+    Address address2 = Address.fromHexString("0xbeef");
+    Address address3 = Address.fromHexString("0xc0ffee");
+
+    var tuple1 = new TrieLogValue<ZkAccountValue>(null, null, false);
+    var tuple2 = new TrieLogValue<ZkAccountValue>(null, null, false);
+    var tuple3 = new TrieLogValue<ZkAccountValue>(null, null, false);
+
+    Map<Address, TrieLogValue<? extends AccountValue>> accountsToUpdate =
+        Map.of(
+            address1, tuple1,
+            address2, tuple2,
+            address3, tuple3);
+
+    Set<Address> hubSeenAccounts = Set.of(address1, address3);
+
+    Map<Address, ? extends LogTuple<? extends AccountValue>> result =
+        ZkTrieLogFactory.filterAccounts(accountsToUpdate, hubSeenAccounts);
+
+    // Verify results
+    assertEquals(1, result.size());
+    assertFalse(result.containsKey(address1));
+    assertFalse(result.containsKey(address3));
+    assertTrue(result.containsKey(address2));
+
+    assertEquals(tuple2, result.get(address2));
+  }
+
+  @Test
+  void testFilterStorage() {
+    Address address1 = Address.fromHexString("0x1234");
+    Address address2 = Address.fromHexString("0x5678");
+    Address address3 = Address.fromHexString("0x9abc");
+
+    StorageSlotKey slot1 = new StorageSlotKey(UInt256.valueOf(1L));
+    StorageSlotKey slot2 = new StorageSlotKey(UInt256.valueOf(2L));
+    StorageSlotKey slot3 = new StorageSlotKey(UInt256.valueOf(3L));
+
+    LogTuple<UInt256> value1 =
+        new TrieLogValue<>(UInt256.valueOf(100), UInt256.valueOf(100), false);
+    LogTuple<UInt256> value2 =
+        new TrieLogValue<>(UInt256.valueOf(200), UInt256.valueOf(200), false);
+    LogTuple<UInt256> value3 =
+        new TrieLogValue<>(UInt256.valueOf(300), UInt256.valueOf(300), false);
+
+    // storageToUpdate: address1 -> {slot1, slot2}, address2 -> {slot3}
+    Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>> storageToUpdate = new HashMap<>();
+    storageToUpdate.put(address1, Map.of(slot1, value1, slot2, value2, slot3, value3));
+    storageToUpdate.put(address2, Map.of(slot2, value2));
+    storageToUpdate.put(address3, Map.of(slot3, value3));
+
+    // hubSeenStorage: address1 -> [slot1 only]
+    Map<Address, Set<Bytes32>> hubSeenStorage =
+        Map.of(
+            address1,
+                Set.of(slot1.getSlotKey().get().toBytes(), slot2.getSlotKey().get().toBytes()),
+            address3, Set.of(slot3.getSlotKey().get().toBytes()));
+
+    // Call method under test
+    Map<Address, Map<StorageSlotKey, ? extends LogTuple<UInt256>>> result =
+        ZkTrieLogFactory.filterStorage(storageToUpdate, hubSeenStorage);
+
+    // Assert address1 is partially filtered, with only slot3 remaining:
+    assertTrue(result.containsKey(address1));
+    Map<StorageSlotKey, ? extends LogTuple<UInt256>> filteredSlots = result.get(address1);
+    assertTrue(filteredSlots.size() == 1);
+    assertTrue(filteredSlots.containsKey(slot3));
+    assertEquals(value3, filteredSlots.get(slot3));
+
+    // Assert address2 storage is not filtered at all
+    assertTrue(result.containsKey(address2));
+    Map<StorageSlotKey, ? extends LogTuple<UInt256>> filteredSlots2 = result.get(address2);
+    assertTrue(filteredSlots2.size() == 1);
+    assertTrue(filteredSlots2.containsKey(slot2));
+    assertEquals(value2, filteredSlots2.get(slot2));
+
+    // Assert address3 is filtered out entirely
+    assertFalse(result.containsKey(address3));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
add an additional zktracer comparison mode, where the bonsai accumulator accountsToUpdate and storageToUpdate are filtered by the hubSeen collections.  

mode is enabled by bitmask 16 for `--plugin-shomei-zktrace-comparison-mode` cli option:
```
        1 = LOGGING
        2 = compare HUB→ACCUMULATOR
        4 = compare ACCUMULATOR→HUB
        8 = DECORATE ACCUMULATOR FROM HUB.
        16 = FILTER ACCUMULATOR BY HUB.
```

--plugin-shomei-zktrace-comparison-mode=0 enables no comparison
--plugin-shomei-zktrace-comparison-mode=7 enables logging and comparison
--plugin-shomei-zktrace-comparison-mode=15 enables logging, comparison and additive decoration of accumulator
--plugin-shomei-zktrace-comparison-mode=31 enables logging, comparison, decoration, and filtering.  

31 means we log all differences and create a trielog that is limited to EXACTLY the contents of hubSeen collections.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
