### PR TITLE
Force the Jar MANIFEST to expose Tracer version data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -256,10 +256,10 @@ jar {
 
     manifest {
         attributes(
-                'Specification-Title': archiveBaseName.get(),
-                'Specification-Version': rootProject.version,
-                'Implementation-Title': archiveBaseName.get(),
-                'Implementation-Version': calculateVersion()
+                'Specification-Title': 'arithmetization',
+                'Specification-Version': "${arithmetizationVersion}",
+                'Implementation-Title': 'arithmetization',
+                'Implementation-Version': "${arithmetizationVersion}"
         )
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description

Since the plugin is still distributed as an uber jar, the MANIFEST data of the Tracer is overwritten, and the Tracer version info is lost, so until we remove the uber jar we can apply this workaround to force the Tracer version data to be written also in the plugin MANIFEST

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
