### PR TITLE
Remove transitive dependencies for vertx-web-client 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -213,7 +213,8 @@ dependencies {
     compileOnly 'com.google.guava:guava'
     compileOnly 'org.slf4j:slf4j-api'
     compileOnly 'info.picocli:picocli'
-    implementation 'io.vertx:vertx-web-client'
+    implementation('io.vertx:vertx-web-client') { transitive = false }
+    implementation('io.vertx:vertx-uri-template') { transitive = false }
     compileOnly 'io.vertx:vertx-web'
     compileOnly 'org.apache.logging.log4j:log4j-slf4j2-impl'
     compileOnly 'org.apache.logging.log4j:log4j-core'
@@ -228,7 +229,6 @@ dependencies {
     // This will be provided by besu package
     compileOnly 'net.consensys.linea.zktracer:arithmetization'
 
-    testImplementation 'io.vertx:vertx-web-client'
     testImplementation 'io.vertx:vertx-web'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation 'com.fasterxml.jackson.core:jackson-annotations'


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description

related to #46
related to #43 

PR removes the transitive dependencies pulled in by vertx-web-client, in favor of the runtime dependencies that will be present in the besu classpath.  This permits the plugin jar to be as small as possible, while still providing the necessary dependencies that a vanilla-besu distribution would not have.

plugin size before: 7.1mb
plugin size after: 203kb

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
