### PR TITLE
Refuse to filter accounts which have changed

### DIFF
--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -139,7 +139,11 @@ public class ZkTrieLogFactory implements TrieLogFactory {
       Map<Address, ? extends LogTuple<? extends AccountValue>> accountsToUpdate,
       Set<Address> hubNotSeenAccounts) {
     return accountsToUpdate.entrySet().stream()
-        .filter(accumulatorEntry -> !hubNotSeenAccounts.contains(accumulatorEntry.getKey()))
+        .filter(
+            accumulatorEntry ->
+                // only filter accounts which are unchanged and in hub-not-seen:
+                !(accumulatorEntry.getValue().isUnchanged()
+                    && hubNotSeenAccounts.contains(accumulatorEntry.getKey())))
         .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
e2e tests have uncovered an intermittent failure where the accounts which are not present in hubSeen are being filtered out of trielogs, even if they have changed.  

This PR is a first step in fixing the problem, by refusing to filter changed accounts from trielogs.  Subsequent work will need to determine if either the hubSeen accounts are intermittently incorrect, or whether the "hubNotSeen" accumulator logic is broken or fragile.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
