### PR TITLE
bugfix: Return no-op tracer if zktracing is disabled

### DIFF
--- a/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
+++ b/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
@@ -67,6 +67,7 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
   private final Supplier<Optional<BigInteger>> chainIdSupplier;
   private final Supplier<Integer> featureMask;
   private final Supplier<Integer> skipTraceUntil;
+  private final Supplier<Boolean> enableZkTracing;
 
   public ZkBlockImportTracerProvider(
       final ShomeiContext ctx, final Supplier<Optional<BigInteger>> chainIdSupplier) {
@@ -74,12 +75,13 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
     this.chainIdSupplier = chainIdSupplier;
     this.skipTraceUntil = Suppliers.memoize(() -> ctx.getCliOptions().zkSkipTraceUntil);
     this.featureMask = Suppliers.memoize(() -> ctx.getCliOptions().zkTraceComparisonMask);
+    this.enableZkTracing = Suppliers.memoize(() -> ctx.getCliOptions().enableZkTracer);
   }
 
   @Override
   public BlockAwareOperationTracer getBlockImportTracer(final BlockHeader blockHeader) {
     // if blockheader is prior to the configured skip-until param, return no_tracing
-    if (skipTraceUntil.get() > blockHeader.getNumber()) {
+    if (!enableZkTracing.get() || (skipTraceUntil.get() > blockHeader.getNumber())) {
       return BlockAwareOperationTracer.NO_TRACING;
     }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
bugfix - do not return a zktracer if zktracing is disabled.  

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
