### PR TITLE
Bugfix/false positive filtering

### DIFF
--- a/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
+++ b/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
@@ -179,7 +179,7 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
       hubSeenStorage.forEach(
           (address, hubSlots) -> {
             var accumulatorSlots = storageToUpdate.get(address);
-            if (accumulatorSlots == null) {
+            if (!hubSlots.isEmpty() && accumulatorSlots == null) {
               alert(
                   () ->
                       LOG.warn(
@@ -211,7 +211,7 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
                                   address.toHexString(),
                                   slot.toHexString())));
               // add missing hubSeenSlots for this address to diff map
-              if (anyEnabled(featureMask.get(), DECORATE_FROM_HUB)) {
+              if (!missingSlots.isEmpty() && anyEnabled(featureMask.get(), DECORATE_FROM_HUB)) {
                 hubStorageFoundDiff.put(address, missingSlots);
               }
             }
@@ -223,7 +223,7 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
       storageToUpdate.forEach(
           (address, accumulatorSlots) -> {
             var hubSlots = hubSeenStorage.get(address);
-            if (hubSlots == null) {
+            if (!accumulatorSlots.isEmpty() && hubSlots == null) {
               // account and all slots are missing:
               alert(
                   () -> {
@@ -255,7 +255,7 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
                       .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
               // add missing hubSeenSlots for this address to accumulator
-              if (anyEnabled(featureMask.get(), DECORATE_FROM_HUB)) {
+              if (!missingSlots.isEmpty() && anyEnabled(featureMask.get(), DECORATE_FROM_HUB)) {
                 hubStorageMissingDiff.put(
                     address,
                     missingSlots.keySet().stream()

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -146,7 +146,12 @@ public class ZkTrieLogFactory implements TrieLogFactory {
                 // changed:
                 var accountPrior = accumulatorEntry.getValue().getPrior();
                 var accountUpdated = accumulatorEntry.getValue().getUpdated();
-                return accountHasChanged(accountPrior, accountUpdated);
+                if (!accountHasChanged(accountPrior, accountUpdated)) {
+                  return false;
+                }
+                LOG.error(
+                    "refusing to filter account value write, address: {}",
+                    accumulatorEntry.getKey().toHexString());
               }
               return true;
             })

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -196,7 +196,7 @@ public class ZkTrieLogFactory implements TrieLogFactory {
             entry -> {
               Address address = entry.getKey();
               Set<Bytes32> notSeenSlots = hubNotSeenStorage.get(address);
-              if (notSeenSlots == null) {
+              if (notSeenSlots == null || notSeenSlots.isEmpty()) {
                 return entry;
               }
 

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -456,6 +456,9 @@ public class ZkTrieLogFactory implements TrieLogFactory {
 
   // helper function to safely assert account diff:
   private static boolean accountHasChanged(AccountValue prior, AccountValue updated) {
+    if (prior == null || updated == null) {
+      return !(prior == null && updated == null);
+    }
     return prior.getNonce() != updated.getNonce()
         || !prior.getBalance().equals(updated.getBalance())
         || !prior.getStorageRoot().equals(updated.getStorageRoot())

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -254,9 +254,9 @@ public class ZkTrieLogFactoryTests {
 
     var mockAccumulator = mock(PathBasedWorldStateUpdateAccumulator.class, RETURNS_DEEP_STUBS);
     var mockAccountMap = new HashMap<Address, PathBasedValue<AccountValue>>();
-    var dummyAcctVal = new ZkAccountValue(0, null, null, null);
-    mockAccountMap.put(mockAddress, new PathBasedValue<>(dummyAcctVal, dummyAcctVal));
-    mockAccountMap.put(mockAddress2, new PathBasedValue<>(dummyAcctVal, dummyAcctVal));
+    ZkAccountValue mockAccountValue = new ZkAccountValue(0, Wei.ZERO, Hash.EMPTY, Hash.EMPTY);
+    mockAccountMap.put(mockAddress, new PathBasedValue<>(mockAccountValue, mockAccountValue));
+    mockAccountMap.put(mockAddress2, new PathBasedValue<>(mockAccountValue, mockAccountValue));
     var mockStorageMap = new HashMap<Address, Map<StorageSlotKey, PathBasedValue<UInt256>>>();
     mockStorageMap.put(
         mockAddress,
@@ -311,9 +311,10 @@ public class ZkTrieLogFactoryTests {
     Address address2 = Address.fromHexString("0xbeef");
     Address address3 = Address.fromHexString("0xc0ffee");
 
-    var tuple1 = new TrieLogValue<ZkAccountValue>(null, null, false);
-    var tuple2 = new TrieLogValue<ZkAccountValue>(null, null, false);
-    var tuple3 = new TrieLogValue<ZkAccountValue>(null, null, false);
+    ZkAccountValue mockAccountVal = new ZkAccountValue(0, Wei.ZERO, Hash.EMPTY, Hash.EMPTY);
+    var tuple1 = new TrieLogValue<ZkAccountValue>(mockAccountVal, mockAccountVal, false);
+    var tuple2 = new TrieLogValue<ZkAccountValue>(mockAccountVal, mockAccountVal, false);
+    var tuple3 = new TrieLogValue<ZkAccountValue>(mockAccountVal, mockAccountVal, false);
 
     Map<Address, TrieLogValue<? extends AccountValue>> accountsToUpdate =
         Map.of(

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -59,7 +59,9 @@ public class ZkTrieLogFactoryTests {
 
   final TestShomeiContext testCtx = TestShomeiContext.create();
   final Address accountFixture = Address.fromHexString("0xdeadbeef");
-  final PluginTrieLogLayer trieLogFixture = new PluginTrieLogLayer(Hash.ZERO);
+  final PluginTrieLogLayer trieLogFixture =
+      new PluginTrieLogLayer(
+          Hash.ZERO, Optional.of(1L), new HashMap<>(), new HashMap<>(), new HashMap<>(), true);
 
   @BeforeEach
   public void setup() {

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -312,9 +312,10 @@ public class ZkTrieLogFactoryTests {
     Address address3 = Address.fromHexString("0xc0ffee");
 
     ZkAccountValue mockAccountVal = new ZkAccountValue(0, Wei.ZERO, Hash.EMPTY, Hash.EMPTY);
+    ZkAccountValue mockUpdatedVal = new ZkAccountValue(1, Wei.ZERO, Hash.EMPTY, Hash.EMPTY);
     var tuple1 = new TrieLogValue<ZkAccountValue>(mockAccountVal, mockAccountVal, false);
     var tuple2 = new TrieLogValue<ZkAccountValue>(mockAccountVal, mockAccountVal, false);
-    var tuple3 = new TrieLogValue<ZkAccountValue>(mockAccountVal, mockAccountVal, false);
+    var tuple3 = new TrieLogValue<ZkAccountValue>(mockAccountVal, mockUpdatedVal, false);
 
     Map<Address, TrieLogValue<? extends AccountValue>> accountsToUpdate =
         Map.of(
@@ -322,18 +323,20 @@ public class ZkTrieLogFactoryTests {
             address2, tuple2,
             address3, tuple3);
 
-    Set<Address> hubSeenAccounts = Set.of(address1, address3);
+    Set<Address> hubUnSeenAccounts = Set.of(address1, address3);
 
     Map<Address, ? extends LogTuple<? extends AccountValue>> result =
-        ZkTrieLogFactory.filterAccounts(accountsToUpdate, hubSeenAccounts);
+        ZkTrieLogFactory.filterAccounts(accountsToUpdate, hubUnSeenAccounts);
 
-    // Verify results
-    assertEquals(1, result.size());
+    // Verify results.
+    // acct1 unseen & filtered, 2 seen & unfiltered, acct3 unseen refused to filter due to change
+    assertEquals(2, result.size());
     assertFalse(result.containsKey(address1));
-    assertFalse(result.containsKey(address3));
     assertTrue(result.containsKey(address2));
+    assertTrue(result.containsKey(address3));
 
     assertEquals(tuple2, result.get(address2));
+    assertEquals(tuple3, result.get(address3));
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
Bugfix for false positive error logs, purporting to refuse to filter the besu accumulator.  The root of the issue was that the accumulator/hubSeen map diff generation code was creating diff maps with empty values.  The presence of a key in the map with empty values (no diffs) was being erroneously reported as an error.  The net behavior was correct, since an empty set would not have filtered any values, but this caused false error logging.  

The fix here is two-fold:
* do not create empty storage diff sets by account, only return map entries which have non-empty diff sets
* additionally check before alerting whether the diff is either null OR empty

This pr also adds safe account diff checking when filtering the accumulator accounts
* assert that the account is _unchanged_ before filtering 

** in the future we might use TrieLogValue<ZKAccountValue>.isUnchanged() for checking account changes rather than the explicit check, but we need to fix a defect with PathBasedAccount.equals() in besu first.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens diff generation and filtering to skip empty/no-op entries and adds a safe account-change check, with tests updated to assert new behavior.
> 
> - **Block tracing (`ZkBlockImportTracerProvider`)**:
>   - Only warn and decorate when `hubSlots`/`accumulatorSlots` are non-empty; build diffs only when missing sets are non-empty.
>   - Gate missing-account warnings on non-empty slot maps.
> - **TrieLog filtering (`ZkTrieLogFactory`)**:
>   - Accounts: when hub has not seen an account, filter only if the account is unchanged; refuse filtering (log error) if changed.
>   - Storage: treat null/empty not-seen slot sets as pass-through; drop per-address entries with empty results.
> - **Tests**:
>   - Update masks, fixtures, and assertions to validate returned diff tuples and new filtering rules.
>   - Adapt to new `PluginTrieLogLayer` constructor and non-null account values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c57d6ac9abbc183b53cd7ede4565ed32a0ffeca7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->