### PR TITLE
fix class cast exception

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-releaseVersion=0.8.7-SNAPSHOT
+releaseVersion=0.8.8-SNAPSHOT
 besuVersion=25.12.0-linea4.1
 arithmetizationVersion=beta-v5-rc8

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -127,13 +127,6 @@ public class ZkTrieLogFactory implements TrieLogFactory {
             __ -> {
               final Account rawAccount = worldStateUpdateAccumulator.getAccount(hubAccount);
               final PathBasedAccount account = unwrapToPathBasedAccount(rawAccount);
-              if (account == null) {
-                LOG.warn(
-                    "cannot resolve PathBasedAccount for hub account {}, raw type: {}",
-                    hubAccount,
-                    rawAccount == null ? "null" : rawAccount.getClass().getName());
-                return null;
-              }
               return new PathBasedValue<>(account, account, false);
             });
       }
@@ -145,16 +138,13 @@ public class ZkTrieLogFactory implements TrieLogFactory {
   }
 
   private static PathBasedAccount unwrapToPathBasedAccount(final Account account) {
-    if (account == null) {
-      return null;
-    }
-    if (account instanceof PathBasedAccount pathBasedAccount) {
-      return pathBasedAccount;
-    }
-    if (account instanceof UpdateTrackingAccount<?> trackingAccount) {
-      return unwrapToPathBasedAccount(trackingAccount.getWrappedAccount());
-    }
-    return null;
+    return switch (account) {
+      case null -> null;
+      case PathBasedAccount pathBasedAccount -> pathBasedAccount;
+      case UpdateTrackingAccount<?> trackingAccount -> unwrapToPathBasedAccount(
+          trackingAccount.getWrappedAccount());
+      default -> null;
+    };
   }
 
   @VisibleForTesting

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -47,6 +47,8 @@ import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.PathBasedAccount;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.PathBasedValue;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.accumulator.PathBasedWorldStateUpdateAccumulator;
+import org.hyperledger.besu.evm.account.Account;
+import org.hyperledger.besu.evm.worldstate.UpdateTrackingAccount;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLog;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLog.LogTuple;
@@ -123,8 +125,15 @@ public class ZkTrieLogFactory implements TrieLogFactory {
         decorated.computeIfAbsent(
             hubAccount,
             __ -> {
-              final PathBasedAccount account =
-                  (PathBasedAccount) worldStateUpdateAccumulator.getAccount(hubAccount);
+              final Account rawAccount = worldStateUpdateAccumulator.getAccount(hubAccount);
+              final PathBasedAccount account = unwrapToPathBasedAccount(rawAccount);
+              if (account == null) {
+                LOG.warn(
+                    "cannot resolve PathBasedAccount for hub account {}, raw type: {}",
+                    hubAccount,
+                    rawAccount == null ? "null" : rawAccount.getClass().getName());
+                return null;
+              }
               return new PathBasedValue<>(account, account, false);
             });
       }
@@ -133,6 +142,19 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     }
 
     return decorated;
+  }
+
+  private static PathBasedAccount unwrapToPathBasedAccount(final Account account) {
+    if (account == null) {
+      return null;
+    }
+    if (account instanceof PathBasedAccount pathBasedAccount) {
+      return pathBasedAccount;
+    }
+    if (account instanceof UpdateTrackingAccount<?> trackingAccount) {
+      return unwrapToPathBasedAccount(trackingAccount.getWrappedAccount());
+    }
+    return null;
   }
 
   @VisibleForTesting

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -49,6 +49,7 @@ import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.BonsaiAccount;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.cache.CodeCache;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.PathBasedValue;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.worldview.accumulator.PathBasedWorldStateUpdateAccumulator;
+import org.hyperledger.besu.evm.worldstate.UpdateTrackingAccount;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLog;
 import org.hyperledger.besu.plugin.services.trielogs.TrieLog.LogTuple;
@@ -419,5 +420,159 @@ public class ZkTrieLogFactoryTests {
 
     // Assert address3 is filtered out entirely
     assertFalse(result.containsKey(address3));
+  }
+
+  @Test
+  void assertDecorateAccountsHandlesUpdateTrackingAccount() {
+    final Address address = Address.fromHexString("0xdeadbeef");
+    final CodeCache codeCache = new CodeCache();
+    final BonsaiAccount bonsaiAccount =
+        new BonsaiAccount(
+            null,
+            address,
+            Hash.hash(address),
+            1,
+            Wei.ONE,
+            Hash.EMPTY_TRIE_HASH,
+            Hash.EMPTY,
+            false,
+            codeCache);
+
+    // Simulate what PathBasedWorldStateUpdateAccumulator.getAccount() returns during
+    // engine_newPayload: AbstractWorldUpdater wraps the raw PathBasedAccount in a
+    // UpdateTrackingAccount before returning it.
+    final UpdateTrackingAccount<BonsaiAccount> trackingAccount =
+        new UpdateTrackingAccount<>(bonsaiAccount);
+
+    final var mockAccumulator =
+        mock(PathBasedWorldStateUpdateAccumulator.class, RETURNS_DEEP_STUBS);
+    doAnswer(__ -> trackingAccount).when(mockAccumulator).getAccount(eq(address));
+
+    final Map<Address, LogTuple<AccountValue>> result =
+        ZkTrieLogFactory.decorateAccounts(new HashMap<>(), Set.of(address), mockAccumulator);
+
+    assertThat(result.containsKey(address)).isTrue();
+    assertThat(result.get(address).getPrior()).isEqualTo(bonsaiAccount);
+    assertThat(result.get(address).getUpdated()).isEqualTo(bonsaiAccount);
+  }
+
+  @Test
+  void assertDecorateAccountsHandlesNestedUpdateTrackingAccount() {
+    final Address address = Address.fromHexString("0xc0ffee");
+    final CodeCache codeCache = new CodeCache();
+    final BonsaiAccount bonsaiAccount =
+        new BonsaiAccount(
+            null,
+            address,
+            Hash.hash(address),
+            0,
+            Wei.ZERO,
+            Hash.EMPTY_TRIE_HASH,
+            Hash.EMPTY,
+            false,
+            codeCache);
+
+    // Two levels of wrapping: UpdateTrackingAccount<UpdateTrackingAccount<BonsaiAccount>>
+    final UpdateTrackingAccount<BonsaiAccount> inner = new UpdateTrackingAccount<>(bonsaiAccount);
+    final UpdateTrackingAccount<UpdateTrackingAccount<BonsaiAccount>> outer =
+        new UpdateTrackingAccount<>(inner);
+
+    final var mockAccumulator =
+        mock(PathBasedWorldStateUpdateAccumulator.class, RETURNS_DEEP_STUBS);
+    doAnswer(__ -> outer).when(mockAccumulator).getAccount(eq(address));
+
+    final Map<Address, LogTuple<AccountValue>> result =
+        ZkTrieLogFactory.decorateAccounts(new HashMap<>(), Set.of(address), mockAccumulator);
+
+    assertThat(result.containsKey(address)).isTrue();
+    assertThat(result.get(address).getPrior()).isEqualTo(bonsaiAccount);
+    assertThat(result.get(address).getUpdated()).isEqualTo(bonsaiAccount);
+  }
+
+  @Test
+  void assertDecorateAccountsSkipsEntryWhenAccountIsNull() {
+    final Address address = Address.fromHexString("0x1234");
+
+    final var mockAccumulator =
+        mock(PathBasedWorldStateUpdateAccumulator.class, RETURNS_DEEP_STUBS);
+    doAnswer(__ -> null).when(mockAccumulator).getAccount(eq(address));
+
+    final Map<Address, LogTuple<AccountValue>> result =
+        ZkTrieLogFactory.decorateAccounts(new HashMap<>(), Set.of(address), mockAccumulator);
+
+    // computeIfAbsent does not insert null-returning mappings
+    assertFalse(result.containsKey(address));
+  }
+
+  @Test
+  void assertHubSeenWithUpdateTrackingAccountIsPresentInTrieLog() {
+    // Reproduces the engine_newPayload crash: getAccount() returns an UpdateTrackingAccount
+    // instead of a bare PathBasedAccount.
+    final var mockTraceProvider = mock(ZkBlockImportTracerProvider.class);
+    final Address wrappedAddress = Address.fromHexString("0xbabe");
+    final Address directAddress = Address.fromHexString("0xc0ffee");
+
+    final var mockDiff =
+        new ZkBlockImportTracerProvider.HubSeenDiff(
+            Set.of(wrappedAddress, directAddress), Collections.emptyMap());
+    final var mockDiffTuple = new ZkBlockImportTracerProvider.HubDiffTuple(mockDiff, mockDiff);
+    doAnswer(__ -> mockDiffTuple).when(mockTraceProvider).compareWithTrace(any(), any());
+
+    final ShomeiCliOptions testOpts = new ShomeiCliOptions();
+    testOpts.zkTraceComparisonMask = 15;
+    testCtx.setCliOptions(testOpts).setBlockImportTraceProvider(mockTraceProvider);
+
+    final CodeCache codeCache = new CodeCache();
+
+    // wrappedAddress: getAccount() returns an UpdateTrackingAccount (engine_newPayload path)
+    final BonsaiAccount wrappedBonsai =
+        new BonsaiAccount(
+            null,
+            wrappedAddress,
+            Hash.hash(wrappedAddress),
+            2,
+            Wei.fromEth(3),
+            Hash.EMPTY_TRIE_HASH,
+            Hash.EMPTY,
+            false,
+            codeCache);
+    final UpdateTrackingAccount<BonsaiAccount> trackingAccount =
+        new UpdateTrackingAccount<>(wrappedBonsai);
+
+    // directAddress: getAccount() returns a bare BonsaiAccount (normal import path)
+    final BonsaiAccount directBonsai =
+        new BonsaiAccount(
+            null,
+            directAddress,
+            Hash.hash(directAddress),
+            0,
+            Wei.ONE,
+            Hash.EMPTY_TRIE_HASH,
+            Hash.EMPTY,
+            false,
+            codeCache);
+
+    final var mockAccumulator =
+        mock(PathBasedWorldStateUpdateAccumulator.class, RETURNS_DEEP_STUBS);
+    doAnswer(__ -> trackingAccount).when(mockAccumulator).getAccount(eq(wrappedAddress));
+    doAnswer(__ -> directBonsai).when(mockAccumulator).getAccount(eq(directAddress));
+    doAnswer(__ -> new HashMap<>()).when(mockAccumulator).getAccountsToUpdate();
+    doAnswer(__ -> new HashMap<>()).when(mockAccumulator).getStorageToUpdate();
+
+    final var mockHeader = mock(BlockHeader.class, RETURNS_DEEP_STUBS);
+    final var factory = new ZkTrieLogFactory(testCtx);
+
+    // Must not throw ClassCastException
+    final var trielog = factory.create(mockAccumulator, mockHeader);
+
+    // Both addresses must appear with the unwrapped PathBasedAccount as prior/updated
+    assertThat(trielog.getAccountChanges().containsKey(wrappedAddress)).isTrue();
+    assertThat(trielog.getAccountChanges().get(wrappedAddress).getPrior()).isEqualTo(wrappedBonsai);
+    assertThat(trielog.getAccountChanges().get(wrappedAddress).getUpdated())
+        .isEqualTo(wrappedBonsai);
+
+    assertThat(trielog.getAccountChanges().containsKey(directAddress)).isTrue();
+    assertThat(trielog.getAccountChanges().get(directAddress).getPrior()).isEqualTo(directBonsai);
+    assertThat(trielog.getAccountChanges().get(directAddress).getUpdated()).isEqualTo(directBonsai);
   }
 }

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -490,21 +490,6 @@ public class ZkTrieLogFactoryTests {
   }
 
   @Test
-  void assertDecorateAccountsSkipsEntryWhenAccountIsNull() {
-    final Address address = Address.fromHexString("0x1234");
-
-    final var mockAccumulator =
-        mock(PathBasedWorldStateUpdateAccumulator.class, RETURNS_DEEP_STUBS);
-    doAnswer(__ -> null).when(mockAccumulator).getAccount(eq(address));
-
-    final Map<Address, LogTuple<AccountValue>> result =
-        ZkTrieLogFactory.decorateAccounts(new HashMap<>(), Set.of(address), mockAccumulator);
-
-    // computeIfAbsent does not insert null-returning mappings
-    assertFalse(result.containsKey(address));
-  }
-
-  @Test
   void assertHubSeenWithUpdateTrackingAccountIsPresentInTrieLog() {
     // Reproduces the engine_newPayload crash: getAccount() returns an UpdateTrackingAccount
     // instead of a bare PathBasedAccount.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description

Replace the direct cast with a recursive unwrapToPathBasedAccount helper that peels off UpdateTrackingAccount layers via getWrappedAccount() until it reaches the underlying PathBasedAccount. This is safe for zero-read accounts because the UpdateTrackingAccount wrapping them carries no modifications  getWrappedAccount() returns the original PathBasedAccount unchanged.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches trie-log generation during block import/trace comparison and changes how accounts are sourced/typed, which could affect downstream consumers if unwrapping returns null unexpectedly; test coverage reduces the risk.
> 
> **Overview**
> Fixes `ZkTrieLogFactory.decorateAccounts` to handle `PathBasedWorldStateUpdateAccumulator.getAccount()` returning an `UpdateTrackingAccount` (including nested wrappers) by recursively unwrapping to the underlying `PathBasedAccount` instead of directly casting.
> 
> Adds regression tests covering direct, nested, and end-to-end `create()` scenarios to prevent `engine_newPayload` crashes, and bumps `releaseVersion` to `0.8.8-SNAPSHOT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d3ff7570588977f1c037ee148a14ab771330ed2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->