### PR TITLE
bump max tracer history to support forced transactions

### DIFF
--- a/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
+++ b/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
@@ -65,7 +65,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
   private static final Logger LOG = LoggerFactory.getLogger(ZkBlockImportTracerProvider.class);
-  private static final int MAX_TRACER_HISTORY_SIZE = 3;
+  private static final int MAX_TRACER_HISTORY_SIZE = 5;
 
   private final Deque<HeaderTracerTuple> tracerHistory = new ConcurrentLinkedDeque<>();
   private final BlockchainService blockchainService;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
Tracer history is a concurrent queue that retains the most recent zk tracers and their corresponding hub state in order to filter bonsai accumulator when building trielogs.  

Forced transactions will use this same mechanism to build trielogs, but not against the head worldstate.  This PR bumps up the cache size from 3 to 5 to accomodate forced transaction proving.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only increases the in-memory tracer FIFO from 3 to 5 entries; potential impact is slightly higher memory retention and different eviction timing.
> 
> **Overview**
> **Increases zk tracer retention depth.** Bumps `ZkBlockImportTracerProvider.MAX_TRACER_HISTORY_SIZE` from `3` to `5`, keeping more recent tracer/header tuples before FIFO eviction to support workflows (e.g., forced transactions) that need older tracers when building trielogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08119b0cbe0b4970f6f1f0f1cf77d7ded5482b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->