### PR TITLE
Besu update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-releaseVersion=0.8.8-SNAPSHOT
-besuVersion=25.12.0-linea4.1
-arithmetizationVersion=beta-v5-rc8
+releaseVersion=1.0.1-SNAPSHOT
+besuVersion=26.2.0
+arithmetizationVersion=beta-v6.0-rc2

--- a/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
+++ b/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
@@ -197,7 +197,7 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
                       LOG.warn(
                           "block {} hub account {} is missing all keys {} in accumulator storage slot modifications",
                           blockHeader.getNumber(),
-                          address.toHexString(),
+                          address.getBytes().toHexString(),
                           hubSlots.stream()
                               .map(Bytes32::toShortHexString)
                               .collect(Collectors.joining(","))));
@@ -220,7 +220,7 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
                               LOG.warn(
                                   "block {} hub account {} slot key {} is missing from accumulator modifications",
                                   blockHeader.getNumber(),
-                                  address.toHexString(),
+                                  address.getBytes().toHexString(),
                                   slot.toHexString())));
               // add missing hubSeenSlots for this address to diff map
               if (!missingSlots.isEmpty() && anyEnabled(featureMask.get(), DECORATE_FROM_HUB)) {
@@ -242,7 +242,7 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
                     LOG.warn(
                         "block {} accumulator storage account {} is missing from hub seen storage modifications",
                         blockHeader.getNumber(),
-                        address.toHexString());
+                        address.getBytes().toHexString());
                     if (anyEnabled(featureMask.get(), FILTER_FROM_HUB)) {
                       // add all accumulator slots for this address to diff map:
                       hubStorageMissingDiff.put(
@@ -286,12 +286,16 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
                               LOG.warn(
                                   "block {} accumulator storage account {} slot key {} value pre {} post {} is missing from hub seen storage modifications",
                                   blockHeader.getNumber(),
-                                  address.toHexString(),
+                                  address.getBytes().toHexString(),
                                   storageSlotKey
                                       .getSlotKey()
                                       .map(Bytes::toHexString)
                                       .orElse(
-                                          "hash::" + storageSlotKey.getSlotHash().toHexString()),
+                                          "hash::"
+                                              + storageSlotKey
+                                                  .getSlotHash()
+                                                  .getBytes()
+                                                  .toHexString()),
                                   Optional.ofNullable(slotVal.getUpdated())
                                       .map(UInt256::toShortHexString)
                                       .orElse("null"),
@@ -330,7 +334,7 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
                         LOG.warn(
                             "block {} hub seen account {} is missing from accumulator updated addresses",
                             blockHeader.getNumber(),
-                            hubAddress.toHexString()));
+                            hubAddress.getBytes().toHexString()));
                 if (anyEnabled(featureMask.get(), DECORATE_FROM_HUB)) {
                   hubAccountsFoundDiff.add(hubAddress);
                 }
@@ -348,7 +352,7 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
                         LOG.warn(
                             "block {} accumulator address to update {} is missing from hub seen accounts, diff: {} ",
                             blockHeader.getNumber(),
-                            accountAddress.toHexString(),
+                            accountAddress.getBytes().toHexString(),
                             accountDiffString(accountsToUpdate.get(accountAddress))));
                 if (anyEnabled(featureMask.get(), FILTER_FROM_HUB)) {
                   hubAccountsMissingDiff.add(accountAddress);
@@ -387,9 +391,11 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
                 "updated is null;prior _Nonce:%d, _Balance:%s, _CodeHash:%s, _StorageRoot: %s",
                 prior.getNonce(),
                 Optional.ofNullable(prior.getBalance()).map(Wei::toShortHexString).orElse("null"),
-                Optional.ofNullable(prior.getCodeHash()).map(Bytes32::toHexString).orElse("null"),
+                Optional.ofNullable(prior.getCodeHash())
+                    .map(h -> h.getBytes().toHexString())
+                    .orElse("null"),
                 Optional.ofNullable(prior.getStorageRoot())
-                    .map(Bytes32::toHexString)
+                    .map(h -> h.getBytes().toHexString())
                     .orElse("null")));
       }
       if (updated != null) {
@@ -398,9 +404,11 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
                 "prior is null;updated _Nonce:%d, _Balance:%s, _CodeHash:%s, _StorageRoot: %s",
                 updated.getNonce(),
                 Optional.ofNullable(updated.getBalance()).map(Wei::toShortHexString).orElse("null"),
-                Optional.ofNullable(updated.getCodeHash()).map(Bytes32::toHexString).orElse("null"),
+                Optional.ofNullable(updated.getCodeHash())
+                    .map(h -> h.getBytes().toHexString())
+                    .orElse("null"),
                 Optional.ofNullable(updated.getStorageRoot())
-                    .map(Bytes32::toHexString)
+                    .map(h -> h.getBytes().toHexString())
                     .orElse("null")));
       }
     } else {
@@ -421,9 +429,11 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
         logBuilder.append(
             String.format(
                 "_CodeHash pre:%s;post:%s",
-                Optional.ofNullable(prior.getCodeHash()).map(Bytes32::toHexString).orElse("null"),
+                Optional.ofNullable(prior.getCodeHash())
+                    .map(h -> h.getBytes().toHexString())
+                    .orElse("null"),
                 Optional.ofNullable(updated.getCodeHash())
-                    .map(Bytes32::toHexString)
+                    .map(h -> h.getBytes().toHexString())
                     .orElse("null")));
       }
       if (!prior.getStorageRoot().equals(updated.getStorageRoot())) {
@@ -431,10 +441,10 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
             String.format(
                 "_StorageRoot pre:%s;post:%s",
                 Optional.ofNullable(prior.getStorageRoot())
-                    .map(Bytes32::toHexString)
+                    .map(h -> h.getBytes().toHexString())
                     .orElse("null"),
                 Optional.ofNullable(updated.getStorageRoot())
-                    .map(Bytes32::toHexString)
+                    .map(h -> h.getBytes().toHexString())
                     .orElse("null")));
       }
     }

--- a/src/main/java/net/consensys/shomei/trielog/PluginTrieLogLayer.java
+++ b/src/main/java/net/consensys/shomei/trielog/PluginTrieLogLayer.java
@@ -157,7 +157,7 @@ public record PluginTrieLogLayer(
   // JSON serialization methods for metadata
   @JsonGetter("blockHash")
   public String getBlockHashHex() {
-    return blockHash.toHexString();
+    return blockHash.getBytes().toHexString();
   }
 
   @JsonGetter("blockNumber")

--- a/src/main/java/net/consensys/shomei/trielog/ZkAccountValue.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkAccountValue.java
@@ -14,7 +14,6 @@
  */
 package net.consensys.shomei.trielog;
 
-import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.AccountValue;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.Wei;
@@ -50,8 +49,8 @@ public record ZkAccountValue(long nonce, Wei balance, Hash storageRoot, Hash cod
 
     out.writeLongScalar(nonce);
     out.writeUInt256Scalar(balance);
-    out.writeBytes(storageRoot);
-    out.writeBytes(codeHash);
+    out.writeBytes(storageRoot.getBytes());
+    out.writeBytes(codeHash.getBytes());
 
     out.endList();
   }
@@ -61,23 +60,23 @@ public record ZkAccountValue(long nonce, Wei balance, Hash storageRoot, Hash cod
 
     final long nonce = in.readLongScalar();
     final Wei balance = Wei.of(in.readUInt256Scalar());
-    Bytes32 storageRoot;
-    Bytes32 codeHash;
+    Hash storageRoot;
+    Hash codeHash;
     if (in.nextIsNull()) {
       storageRoot = Hash.EMPTY_TRIE_HASH;
       in.skipNext();
     } else {
-      storageRoot = in.readBytes32();
+      storageRoot = Hash.wrap(in.readBytes32());
     }
     if (in.nextIsNull()) {
       codeHash = Hash.EMPTY;
       in.skipNext();
     } else {
-      codeHash = in.readBytes32();
+      codeHash = Hash.wrap(in.readBytes32());
     }
 
     in.leaveList();
 
-    return new ZkAccountValue(nonce, balance, Hash.wrap(storageRoot), Hash.wrap(codeHash));
+    return new ZkAccountValue(nonce, balance, storageRoot, codeHash);
   }
 }

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -164,7 +164,7 @@ public class ZkTrieLogFactory implements TrieLogFactory {
                 }
                 LOG.error(
                     "refusing to filter account value write, address: {}",
-                    accumulatorEntry.getKey().toHexString());
+                    accumulatorEntry.getKey().getBytes().toHexString());
               }
               return true;
             })
@@ -247,7 +247,7 @@ public class ZkTrieLogFactory implements TrieLogFactory {
                               LOG.error(
                                   "refusing to filter slot value write, "
                                       + "address: {}, slot key: {}, prior: {}, updated: {}",
-                                  address.toHexString(),
+                                  address.getBytes().toHexString(),
                                   trieLogKey.getSlotKey().map(UInt256::toHexString).orElse("empty"),
                                   Optional.ofNullable(trieLogVal.getPrior())
                                       .map(UInt256::toHexString)
@@ -291,12 +291,12 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     addresses.addAll(layer.getStorageChanges().keySet());
 
     output.startList(); // container
-    output.writeBytes(layer.getBlockHash());
+    output.writeBytes(layer.getBlockHash().getBytes());
     // optionally write block number
     layer.getBlockNumber().ifPresent(output::writeLongScalar);
     for (final Address address : addresses) {
       output.startList(); // this change
-      output.writeBytes(address);
+      output.writeBytes(address.getBytes());
 
       final LogTuple<Bytes> codeChange = layer.getCodeChanges().get(address);
       if (codeChange == null || codeChange.isUnchanged()) {
@@ -326,7 +326,7 @@ public class ZkTrieLogFactory implements TrieLogFactory {
           output.startList();
 
           StorageSlotKey storageSlotKey = storageChangeEntry.getKey();
-          output.writeBytes(storageSlotKey.getSlotHash());
+          output.writeBytes(storageSlotKey.getSlotHash().getBytes());
           writeInnerRlp(storageChangeEntry.getValue(), output, RLPOutput::writeUInt256Scalar);
           if (storageSlotKey.getSlotKey().isPresent()) {
             output.writeUInt256Scalar(storageSlotKey.getSlotKey().get());

--- a/src/main/java/net/consensys/shomei/util/HashSerializer.java
+++ b/src/main/java/net/consensys/shomei/util/HashSerializer.java
@@ -27,6 +27,6 @@ public class HashSerializer extends JsonSerializer<Hash> {
   public void serialize(
       final Hash value, final JsonGenerator gen, final SerializerProvider serializers)
       throws IOException {
-    gen.writeString(value.toHexString());
+    gen.writeString(value.getBytes().toHexString());
   }
 }

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -187,7 +187,7 @@ public class ZkTrieLogFactoryTests {
         new BonsaiAccount(
             null,
             mockAddress,
-            Hash.hash(mockAddress),
+            Hash.hash(mockAddress.getBytes()),
             0,
             Wei.ONE,
             Hash.EMPTY_TRIE_HASH,
@@ -198,7 +198,7 @@ public class ZkTrieLogFactoryTests {
         new BonsaiAccount(
             null,
             mockAddress2,
-            Hash.hash(mockAddress2),
+            Hash.hash(mockAddress2.getBytes()),
             0,
             Wei.ZERO,
             Hash.EMPTY_TRIE_HASH,
@@ -430,7 +430,7 @@ public class ZkTrieLogFactoryTests {
         new BonsaiAccount(
             null,
             address,
-            Hash.hash(address),
+            Hash.hash(address.getBytes()),
             1,
             Wei.ONE,
             Hash.EMPTY_TRIE_HASH,
@@ -464,7 +464,7 @@ public class ZkTrieLogFactoryTests {
         new BonsaiAccount(
             null,
             address,
-            Hash.hash(address),
+            Hash.hash(address.getBytes()),
             0,
             Wei.ZERO,
             Hash.EMPTY_TRIE_HASH,
@@ -514,7 +514,7 @@ public class ZkTrieLogFactoryTests {
         new BonsaiAccount(
             null,
             wrappedAddress,
-            Hash.hash(wrappedAddress),
+            Hash.hash(wrappedAddress.getBytes()),
             2,
             Wei.fromEth(3),
             Hash.EMPTY_TRIE_HASH,
@@ -529,7 +529,7 @@ public class ZkTrieLogFactoryTests {
         new BonsaiAccount(
             null,
             directAddress,
-            Hash.hash(directAddress),
+            Hash.hash(directAddress.getBytes()),
             0,
             Wei.ONE,
             Hash.EMPTY_TRIE_HASH,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades the Besu dependency and adjusts trie-log/RLP serialization and logging to use new `Hash`/`Address` byte APIs; mistakes here could cause incompatibility with persisted trie logs or tooling that consumes these encodings.
> 
> **Overview**
> Bumps core dependency versions (`besuVersion` to `26.2.0` and arithmetization to `beta-v6.0-rc2`) and updates the project snapshot version.
> 
> Aligns hash/address handling with the newer Besu datatypes by switching various logs and JSON fields to use `getBytes().toHexString()` instead of `toHexString()`, and by updating trie-log RLP serialization to write raw bytes for `Hash`, `Address`, and storage slot hashes.
> 
> Updates `ZkAccountValue` RLP encoding/decoding to treat `storageRoot` and `codeHash` as `Hash` directly (wrapping `readBytes32()`), and adjusts tests to hash `Address.getBytes()` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79bc7eccaed44b95ad13e757083fb60244f77a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->