### PR TITLE
ZkBlockImportTracerProvider fix

### DIFF
--- a/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
+++ b/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
@@ -126,7 +126,8 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
     // Iterate from the beginning (oldest) to find the earliest tracer for the given block header.
     // Match by exact block hash first. Also match when the tuple's header hash equals the lookup
     // header's parentHash — this covers the eth_simulateV1 path where EthSimulateV1 calls
-    // getBlockImportTracer(parentHeader) but compareWithTrace receives the simulated block's header.
+    // getBlockImportTracer(parentHeader) but compareWithTrace receives the simulated block's
+    // header.
     return tracerHistory.stream()
         .filter(
             tuple ->

--- a/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
+++ b/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
@@ -123,9 +123,15 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
   }
 
   public Optional<HeaderTracerTuple> getEarliestTracerTuple(final BlockHeader blockHeader) {
-    // Iterate from the beginning (oldest) to find the earliest tracer for the given block header
+    // Iterate from the beginning (oldest) to find the earliest tracer for the given block header.
+    // Match by exact block hash first. Also match when the tuple's header hash equals the lookup
+    // header's parentHash — this covers the eth_simulateV1 path where EthSimulateV1 calls
+    // getBlockImportTracer(parentHeader) but compareWithTrace receives the simulated block's header.
     return tracerHistory.stream()
-        .filter(tuple -> tuple.header().getBlockHash().equals(blockHeader.getBlockHash()))
+        .filter(
+            tuple ->
+                tuple.header().getBlockHash().equals(blockHeader.getBlockHash())
+                    || tuple.header().getBlockHash().equals(blockHeader.getParentHash()))
         .findFirst();
   }
 
@@ -149,7 +155,6 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
 
     var zkTracerTuple =
         getEarliestTracerTuple(blockHeader)
-            .filter(t -> t.header().getBlockHash().equals(blockHeader.getBlockHash()))
             .orElseThrow(
                 () ->
                     new IllegalStateException(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tracer instance is used for `compareWithTrace`, which can affect trace-vs-accumulator mismatch detection and downstream decoration/filtering behavior. Scope is small and localized but impacts tracing correctness.
> 
> **Overview**
> Fixes tracer selection during trace/accumulator comparison by broadening `getEarliestTracerTuple` matching to accept either the exact `blockHash` or the lookup header’s `parentHash` (to support the `eth_simulateV1` flow).
> 
> Removes the redundant strict `blockHash` filter in `compareWithTrace`, preventing false “Block not found in the Tracer” failures when the comparison is invoked with a simulated block header while the tracer was created for its parent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27af81e6a555adec71f5a3aa2e73cb37ed6cc6dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->