### PR TITLE
Refactor tracer caching, move to traceEndBlock

### DIFF
--- a/src/main/java/net/consensys/shomei/blocktracing/TrackingWrappedZkTracer.java
+++ b/src/main/java/net/consensys/shomei/blocktracing/TrackingWrappedZkTracer.java
@@ -21,6 +21,7 @@ import net.consensys.linea.zktracer.ZkTracer;
 import java.math.BigInteger;
 import java.util.function.BiConsumer;
 
+import graphql.VisibleForTesting;
 import org.hyperledger.besu.plugin.data.BlockBody;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 
@@ -48,6 +49,7 @@ public class TrackingWrappedZkTracer extends ZkTracer {
     this.executeTrackingAction(blockHeader);
   }
 
+  @VisibleForTesting
   void executeTrackingAction(BlockHeader blockHeader) {
     trackAction.accept(blockHeader, this);
   }

--- a/src/main/java/net/consensys/shomei/blocktracing/TrackingWrappedZkTracer.java
+++ b/src/main/java/net/consensys/shomei/blocktracing/TrackingWrappedZkTracer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright ConsenSys 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.shomei.blocktracing;
+
+import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
+import net.consensys.linea.zktracer.Fork;
+import net.consensys.linea.zktracer.ZkTracer;
+
+import java.math.BigInteger;
+import java.util.function.BiConsumer;
+
+import org.hyperledger.besu.plugin.data.BlockBody;
+import org.hyperledger.besu.plugin.data.BlockHeader;
+
+/**
+ * LineCountingTracer extends ZkTracer by adding a BiConsumer tracking action.
+ *
+ * <p>The tracking action occurs after traceEndBlock, signifying the tracer is 'complete'.
+ */
+public class TrackingWrappedZkTracer extends ZkTracer {
+
+  final BiConsumer<BlockHeader, ZkTracer> trackAction;
+
+  TrackingWrappedZkTracer(
+      final Fork fork,
+      final LineaL1L2BridgeSharedConfiguration bridgeConfiguration,
+      BigInteger chainId,
+      BiConsumer<BlockHeader, ZkTracer> trackAction) {
+    super(fork, bridgeConfiguration, chainId);
+    this.trackAction = trackAction;
+  }
+
+  @Override
+  public void traceEndBlock(final BlockHeader blockHeader, final BlockBody blockBody) {
+    super.traceEndBlock(blockHeader, blockBody);
+    this.executeTrackingAction(blockHeader);
+  }
+
+  void executeTrackingAction(BlockHeader blockHeader) {
+    trackAction.accept(blockHeader, this);
+  }
+}

--- a/src/main/java/net/consensys/shomei/blocktracing/TrackingWrappedZkTracer.java
+++ b/src/main/java/net/consensys/shomei/blocktracing/TrackingWrappedZkTracer.java
@@ -21,7 +21,7 @@ import net.consensys.linea.zktracer.ZkTracer;
 import java.math.BigInteger;
 import java.util.function.BiConsumer;
 
-import graphql.VisibleForTesting;
+import com.google.common.annotations.VisibleForTesting;
 import org.hyperledger.besu.plugin.data.BlockBody;
 import org.hyperledger.besu.plugin.data.BlockHeader;
 

--- a/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
+++ b/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
@@ -95,20 +95,21 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
     final HardforkId.MainnetHardforkId forkId =
         (HardforkId.MainnetHardforkId) blockchainService.getHardforkId(blockHeader);
     final ZkTracer zkTracer =
-        new ZkTracer(
+        new TrackingWrappedZkTracer(
             fromMainnetHardforkIdToTracerFork(forkId),
             LineaL1L2BridgeSharedConfiguration.EMPTY,
-            chainIdSupplier.get().orElseThrow(() -> new RuntimeException("Chain Id unavailable")));
+            chainIdSupplier.get().orElseThrow(() -> new RuntimeException("Chain Id unavailable")),
+            (h, t) -> {
+              // Add to the FIFO list
+              tracerHistory.addLast(new HeaderTracerTuple(h, t));
+
+              // Evict oldest entries if we exceed the max size
+              while (tracerHistory.size() > MAX_TRACER_HISTORY_SIZE) {
+                tracerHistory.removeFirst();
+              }
+            });
 
     LOG.debug("returning zkTracer for {}", headerLogString(blockHeader));
-
-    // Add to the FIFO list
-    tracerHistory.addLast(new HeaderTracerTuple(blockHeader, zkTracer));
-
-    // Evict oldest entries if we exceed the max size
-    while (tracerHistory.size() > MAX_TRACER_HISTORY_SIZE) {
-      tracerHistory.removeFirst();
-    }
 
     return zkTracer;
   }

--- a/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
+++ b/src/main/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProvider.java
@@ -100,12 +100,11 @@ public class ZkBlockImportTracerProvider implements BlockImportTracerProvider {
             LineaL1L2BridgeSharedConfiguration.EMPTY,
             chainIdSupplier.get().orElseThrow(() -> new RuntimeException("Chain Id unavailable")),
             (h, t) -> {
-              // Add to the FIFO list
-              tracerHistory.addLast(new HeaderTracerTuple(h, t));
-
-              // Evict oldest entries if we exceed the max size
-              while (tracerHistory.size() > MAX_TRACER_HISTORY_SIZE) {
-                tracerHistory.removeFirst();
+              synchronized (ZkBlockImportTracerProvider.this) {
+                tracerHistory.addLast(new HeaderTracerTuple(h, t));
+                while (tracerHistory.size() > MAX_TRACER_HISTORY_SIZE) {
+                  tracerHistory.pollFirst();
+                }
               }
             });
 

--- a/src/test/java/net/consensys/shomei/blocktracing/TrackingWrappedZkTracerTest.java
+++ b/src/test/java/net/consensys/shomei/blocktracing/TrackingWrappedZkTracerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright ConsenSys 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package net.consensys.shomei.blocktracing;
+
+import static net.consensys.linea.zktracer.Fork.fromMainnetHardforkIdToTracerFork;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import net.consensys.linea.plugins.config.LineaL1L2BridgeSharedConfiguration;
+import net.consensys.linea.zktracer.ZkTracer;
+
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+
+import org.hyperledger.besu.datatypes.Address;
+import org.hyperledger.besu.datatypes.HardforkId;
+import org.hyperledger.besu.evm.worldstate.WorldView;
+import org.hyperledger.besu.plugin.data.BlockBody;
+import org.hyperledger.besu.plugin.data.BlockHeader;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class TrackingWrappedZkTracerTest {
+
+  @Mock BlockHeader mockHeader;
+  @Mock BlockBody mockBody;
+  @Mock WorldView mockWorldView;
+
+  private TrackingWrappedZkTracer createTracer(final BiConsumer<BlockHeader, ZkTracer> action) {
+    return new TrackingWrappedZkTracer(
+        fromMainnetHardforkIdToTracerFork(HardforkId.MainnetHardforkId.OSAKA),
+        LineaL1L2BridgeSharedConfiguration.EMPTY,
+        BigInteger.valueOf(59144L),
+        action);
+  }
+
+  @Test
+  void trackActionIsCalledAfterTraceEndBlock() {
+    AtomicReference<BlockHeader> capturedHeader = new AtomicReference<>();
+    AtomicReference<ZkTracer> capturedTracer = new AtomicReference<>();
+
+    var tracer =
+        createTracer(
+            (header, zkTracer) -> {
+              capturedHeader.set(header);
+              capturedTracer.set(zkTracer);
+            });
+
+    tracer.traceEndBlock(mockHeader, mockBody);
+
+    assertThat(capturedHeader.get()).isSameAs(mockHeader);
+    assertThat(capturedTracer.get()).isSameAs(tracer);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void trackActionIsNotCalledBeforeTraceEndBlock() {
+    BiConsumer<BlockHeader, ZkTracer> mockAction = mock(BiConsumer.class);
+    var tracer = createTracer(mockAction);
+
+    tracer.traceStartBlock(mockWorldView, mockHeader, Address.fromHexString("0x1337"));
+
+    verify(mockAction, never()).accept(mockHeader, tracer);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void trackActionIsCalledExactlyOncePerTraceEndBlock() {
+    BiConsumer<BlockHeader, ZkTracer> mockAction = mock(BiConsumer.class);
+    var tracer = createTracer(mockAction);
+
+    tracer.traceEndBlock(mockHeader, mockBody);
+    tracer.traceEndBlock(mockHeader, mockBody);
+
+    verify(mockAction, times(2)).accept(mockHeader, tracer);
+  }
+}

--- a/src/test/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProviderTest.java
+++ b/src/test/java/net/consensys/shomei/blocktracing/ZkBlockImportTracerProviderTest.java
@@ -430,9 +430,17 @@ public class ZkBlockImportTracerProviderTest {
     when(mockBlockchainService.getChainId()).thenReturn(Optional.of(BigInteger.valueOf(1L)));
 
     // Create tracers for each block header
-    comparator.getBlockImportTracer(header1);
-    comparator.getBlockImportTracer(header2);
-    comparator.getBlockImportTracer(header3);
+    var tracer1 = comparator.getBlockImportTracer(header1);
+    var tracer2 = comparator.getBlockImportTracer(header2);
+    var tracer3 = comparator.getBlockImportTracer(header3);
+
+    // call traceEndBlock to trigger the cache add action
+    assertThat(tracer1).isInstanceOf(TrackingWrappedZkTracer.class);
+    assertThat(tracer2).isInstanceOf(TrackingWrappedZkTracer.class);
+    assertThat(tracer3).isInstanceOf(TrackingWrappedZkTracer.class);
+    ((TrackingWrappedZkTracer) tracer1).executeTrackingAction(header1);
+    ((TrackingWrappedZkTracer) tracer2).executeTrackingAction(header2);
+    ((TrackingWrappedZkTracer) tracer3).executeTrackingAction(header3);
 
     // Verify getCurrentTracerTuple returns the correct tracer for each block
     var currentTracer1 = comparator.getCurrentTracerTuple(header1);
@@ -492,13 +500,21 @@ public class ZkBlockImportTracerProviderTest {
     assertNotNull(tracer2);
     assertNotNull(tracer3);
 
-    // getCurrentTracerTuple should return the LATEST (third) tracer
+    // call traceEndBlock to trigger the cache add action
+    assertThat(tracer1).isInstanceOf(TrackingWrappedZkTracer.class);
+    assertThat(tracer2).isInstanceOf(TrackingWrappedZkTracer.class);
+    assertThat(tracer3).isInstanceOf(TrackingWrappedZkTracer.class);
+    ((TrackingWrappedZkTracer) tracer1).executeTrackingAction(header);
+    ((TrackingWrappedZkTracer) tracer2).executeTrackingAction(header);
+    // DO NOT call executeTrackingAction for tracer 3 to mimic an incomplete tracing state
+
+    // getCurrentTracerTuple should return the LATEST COMPLETE(second) tracer
     var currentTracer = comparator.getCurrentTracerTuple(header);
     assertTrue(currentTracer.isPresent());
     assertEquals(header.getBlockHash(), currentTracer.get().header().getBlockHash());
-    assertEquals(tracer3, currentTracer.get().zkTracer());
+    assertEquals(tracer2, currentTracer.get().zkTracer());
 
-    // getEarliestTracerTuple should return the EARLIEST (first) tracer
+    // getEarliestTracerTuple should return the EARLIEST COMPLETE (first) tracer
     var earliestTracer = comparator.getEarliestTracerTuple(header);
     assertTrue(earliestTracer.isPresent());
     assertEquals(header.getBlockHash(), earliestTracer.get().header().getBlockHash());


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description
This PR moves the behavior of caching zktracers to `traceEndBlock()` rather than automatically caching zkTracers when they begin.  There are two benefits:

1. if we wait to cache untilTraceEndblock() we will for sure have the correct/resulting blockHeader for the block which is traced.  For a block being imported, we always have the blockheader when we get the tracer for import.  But if for example we are tracing a forced transaction on a historical block, we do NOT have the final blockheader until traceEndBlock.  Deferring the addition of the tracer to the recently-traced-block-cache until traceEndBlock ensures we will always have the correct blockheader

2. if we wait until the tracer is complete to cache it, this also resolves a longstanding race where repeated newPayload calls can result in failures when building a trie log.  If for example the trielog for the first execution gets the tracer for a subsequent newPayload call for the same block, the tracer may or may not be "complete" by the time the trielog factory is using the hub state for comparison.  Deferring the caching of tracers to traceEndBlock means that any tracer in the cache for the corresponding block header should already be 'complete' and result in a correct filtering of the bonsai accumulator.


## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
related to #86 

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tracer lifecycle and the timing of when tracers become visible for trie-log comparisons; incorrect callback invocation or ordering could cause missing/incorrect cached tracers under concurrent imports.
> 
> **Overview**
> Defers adding newly created `ZkTracer` instances to `ZkBlockImportTracerProvider`’s FIFO history until the tracer finishes (`traceEndBlock`), rather than caching immediately on creation.
> 
> Introduces `TrackingWrappedZkTracer`, a `ZkTracer` subclass that runs a provided tracking callback after `traceEndBlock`; `ZkBlockImportTracerProvider` now returns this wrapper and uses the callback to append/evict entries under synchronization. Tests are updated/added to assert the callback timing and to model “incomplete” tracers being absent from `getCurrentTracerTuple`/`getEarliestTracerTuple` results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca2c3cbf8ea671e852a8ad0d142a3a718773ee7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->