### PR TITLE
quick swag at timestamp-in-trielog

### DIFF
--- a/src/main/java/net/consensys/shomei/trielog/PluginTrieLogLayer.java
+++ b/src/main/java/net/consensys/shomei/trielog/PluginTrieLogLayer.java
@@ -48,6 +48,7 @@ import org.hyperledger.besu.plugin.services.trielogs.TrieLog;
 public record PluginTrieLogLayer(
     @JsonIgnore Hash blockHash,
     @JsonIgnore Optional<Long> blockNumber,
+    @JsonIgnore Optional<Long> timestamp,
     @JsonIgnore Map<Address, TrieLog.LogTuple<AccountValue>> accounts,
     @JsonIgnore Map<Address, TrieLog.LogTuple<Bytes>> code,
     @JsonIgnore Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>> storage,
@@ -58,17 +59,19 @@ public record PluginTrieLogLayer(
   public PluginTrieLogLayer(
       Hash blockHash,
       Optional<Long> blockNumber,
+      Optional<Long> timestamp,
       Map<Address, TrieLog.LogTuple<AccountValue>> accounts,
       Map<Address, TrieLog.LogTuple<Bytes>> code,
       Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>> storage,
       boolean frozen) {
-    this(blockHash, blockNumber, accounts, code, storage, frozen, Optional.empty());
+    this(blockHash, blockNumber, timestamp, accounts, code, storage, frozen, Optional.empty());
   }
 
   /** Creates a new PluginTrieLogLayer with blockhash and empty maps to deserialize into. */
   public PluginTrieLogLayer(final Hash blockHash) {
     this(
         blockHash,
+        Optional.empty(),
         Optional.empty(),
         new HashMap<>(),
         new HashMap<>(),
@@ -91,6 +94,10 @@ public record PluginTrieLogLayer(
   @Override
   public Optional<Long> getBlockNumber() {
     return blockNumber;
+  }
+
+  public Optional<Long> getTimestamp() {
+    return timestamp;
   }
 
   @Override
@@ -163,6 +170,11 @@ public record PluginTrieLogLayer(
   @JsonGetter("blockNumber")
   public Long getBlockNumberValue() {
     return blockNumber.orElse(null);
+  }
+
+  @JsonGetter("timestamp")
+  public Long getTimestampValue() {
+    return timestamp.orElse(null);
   }
 
   @JsonGetter("zkTraceComparisonFeatures")

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -104,6 +104,7 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     return new PluginTrieLogLayer(
         blockHeader.getBlockHash(),
         Optional.of(blockHeader.getNumber()),
+        Optional.of(blockHeader.getTimestamp()),
         (Map<Address, LogTuple<AccountValue>>) accountsToUpdate,
         (Map<Address, LogTuple<Bytes>>) codeToUpdate,
         (Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>>) storageToUpdate,
@@ -294,6 +295,12 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     output.writeBytes(layer.getBlockHash().getBytes());
     // optionally write block number
     layer.getBlockNumber().ifPresent(output::writeLongScalar);
+
+    if (layer instanceof PluginTrieLogLayer ptl) {
+      // optionally write block timestamp
+      ptl.getTimestamp().ifPresent(output::writeLongScalar);
+    }
+
     for (final Address address : addresses) {
       output.startList(); // this change
       output.writeBytes(address.getBytes());
@@ -373,6 +380,12 @@ public class ZkTrieLogFactory implements TrieLogFactory {
             .filter(isPresent -> isPresent)
             .map(__ -> input.readLongScalar());
 
+    // timestamp is optional
+    Optional<Long> timestamp =
+        Optional.of(!input.nextIsList())
+            .filter(isPresent -> isPresent)
+            .map(__ -> input.readLongScalar());
+
     while (!input.isEndOfCurrentList() && input.nextIsList()) {
       input.enterList();
       final Address address = Address.readFrom(input);
@@ -438,7 +451,7 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     input.leaveListLenient();
 
     return new PluginTrieLogLayer(
-        blockHash, blockNumber, accounts, code, storage, true, zkTraceComparisonFeature);
+        blockHash, blockNumber, timestamp, accounts, code, storage, true, zkTraceComparisonFeature);
   }
 
   protected static <T> T nullOrValue(final RLPInput input, final Function<RLPInput, T> reader) {

--- a/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogMetadataTests.java
+++ b/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogMetadataTests.java
@@ -117,7 +117,14 @@ public class GetShomeiTrieLogMetadataTests {
 
     PluginTrieLogLayer mockLayer =
         new PluginTrieLogLayer(
-            Hash.ZERO, Optional.of(123L), accounts, code, storage, true, Optional.of(24));
+            Hash.ZERO,
+            Optional.of(123L),
+            Optional.of(1L),
+            accounts,
+            code,
+            storage,
+            true,
+            Optional.of(24));
 
     // mock single log response
     when(mockProvider.getTrieLogLayer(123)).thenReturn(Optional.of(mockLayer));
@@ -156,6 +163,7 @@ public class GetShomeiTrieLogMetadataTests {
             Hash.fromHexString(
                 "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
             Optional.of(456L),
+            Optional.of(1L),
             Map.of(),
             Map.of(),
             Map.of(),

--- a/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogsTests.java
+++ b/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogsTests.java
@@ -57,7 +57,14 @@ public class GetShomeiTrieLogsTests {
 
   PluginTrieLogLayer mockLayer =
       new PluginTrieLogLayer(
-          Hash.ZERO, Optional.of(0L), Map.of(), Map.of(), Map.of(), true, Optional.empty());
+          Hash.ZERO,
+          Optional.of(0L),
+          Optional.of(1L),
+          Map.of(),
+          Map.of(),
+          Map.of(),
+          true,
+          Optional.empty());
 
   MockJsonRpcHttpVerticle verticle;
   WebClient client;

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -65,6 +65,7 @@ public class ZkTrieLogFactoryTests {
       new PluginTrieLogLayer(
           Hash.ZERO,
           Optional.of(1L),
+          Optional.of(1L),
           new HashMap<>(),
           new HashMap<>(),
           new HashMap<>(),
@@ -99,7 +100,13 @@ public class ZkTrieLogFactoryTests {
     assertDoesNotThrow(
         () -> {
           new PluginTrieLogLayer(
-              Hash.ZERO, Optional.of(1L), new HashMap<>(), new HashMap<>(), new HashMap<>(), true);
+              Hash.ZERO,
+              Optional.of(1L),
+              Optional.of(1L),
+              new HashMap<>(),
+              new HashMap<>(),
+              new HashMap<>(),
+              true);
         });
   }
 

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogObserverTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogObserverTests.java
@@ -59,6 +59,7 @@ public class ZkTrieLogObserverTests {
       new PluginTrieLogLayer(
           Hash.ZERO,
           Optional.of(1337L),
+          Optional.of(1L),
           Map.of(
               Address.ZERO,
               new TrieLogValue<>(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the trie log wire/storage encoding (RLP field ordering) and could break compatibility if any consumers assume the previous container layout, though the field is optional and decoding is lenient.
> 
> **Overview**
> Adds an optional `timestamp` field to `PluginTrieLogLayer` and exposes it via JSON metadata (`timestamp`) alongside existing `blockHash`/`blockNumber` fields.
> 
> Updates `ZkTrieLogFactory` to populate the timestamp from the `BlockHeader`, and extends RLP serialization/deserialization to optionally write/read the timestamp after the optional block number (with `instanceof PluginTrieLogLayer` guarding for older `TrieLog` implementations). Tests are updated to construct layers with timestamps and validate the new metadata/codec behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30f70b8308b7b061d23025043057de679f0869b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->