### PR TITLE
Sending timestamp to eth_simulateV1 as an override

### DIFF
--- a/src/main/java/net/consensys/shomei/trielog/PluginTrieLogLayer.java
+++ b/src/main/java/net/consensys/shomei/trielog/PluginTrieLogLayer.java
@@ -67,6 +67,45 @@ public record PluginTrieLogLayer(
     this(blockHash, blockNumber, timestamp, accounts, code, storage, frozen, Optional.empty());
   }
 
+  /** Backward-compatible constructor without timestamp. */
+  public PluginTrieLogLayer(
+      Hash blockHash,
+      Optional<Long> blockNumber,
+      Map<Address, TrieLog.LogTuple<AccountValue>> accounts,
+      Map<Address, TrieLog.LogTuple<Bytes>> code,
+      Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>> storage,
+      boolean frozen) {
+    this(
+        blockHash,
+        blockNumber,
+        Optional.empty(),
+        accounts,
+        code,
+        storage,
+        frozen,
+        Optional.empty());
+  }
+
+  /** Backward-compatible canonical constructor without timestamp. */
+  public PluginTrieLogLayer(
+      Hash blockHash,
+      Optional<Long> blockNumber,
+      Map<Address, TrieLog.LogTuple<AccountValue>> accounts,
+      Map<Address, TrieLog.LogTuple<Bytes>> code,
+      Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>> storage,
+      boolean frozen,
+      Optional<Integer> zkTraceComparisonFeature) {
+    this(
+        blockHash,
+        blockNumber,
+        Optional.empty(),
+        accounts,
+        code,
+        storage,
+        frozen,
+        zkTraceComparisonFeature);
+  }
+
   /** Creates a new PluginTrieLogLayer with blockhash and empty maps to deserialize into. */
   public PluginTrieLogLayer(final Hash blockHash) {
     this(

--- a/src/main/java/net/consensys/shomei/trielog/PluginTrieLogLayer.java
+++ b/src/main/java/net/consensys/shomei/trielog/PluginTrieLogLayer.java
@@ -48,6 +48,7 @@ import org.hyperledger.besu.plugin.services.trielogs.TrieLog;
 public record PluginTrieLogLayer(
     @JsonIgnore Hash blockHash,
     @JsonIgnore Optional<Long> blockNumber,
+    @JsonIgnore Optional<Long> timestamp,
     @JsonIgnore Map<Address, TrieLog.LogTuple<AccountValue>> accounts,
     @JsonIgnore Map<Address, TrieLog.LogTuple<Bytes>> code,
     @JsonIgnore Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>> storage,
@@ -58,17 +59,19 @@ public record PluginTrieLogLayer(
   public PluginTrieLogLayer(
       Hash blockHash,
       Optional<Long> blockNumber,
+      Optional<Long> timestamp,
       Map<Address, TrieLog.LogTuple<AccountValue>> accounts,
       Map<Address, TrieLog.LogTuple<Bytes>> code,
       Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>> storage,
       boolean frozen) {
-    this(blockHash, blockNumber, accounts, code, storage, frozen, Optional.empty());
+    this(blockHash, blockNumber, timestamp, accounts, code, storage, frozen, Optional.empty());
   }
 
   /** Creates a new PluginTrieLogLayer with blockhash and empty maps to deserialize into. */
   public PluginTrieLogLayer(final Hash blockHash) {
     this(
         blockHash,
+        Optional.empty(),
         Optional.empty(),
         new HashMap<>(),
         new HashMap<>(),
@@ -91,6 +94,10 @@ public record PluginTrieLogLayer(
   @Override
   public Optional<Long> getBlockNumber() {
     return blockNumber;
+  }
+
+  public Optional<Long> getTimestamp() {
+    return timestamp;
   }
 
   @Override
@@ -163,6 +170,11 @@ public record PluginTrieLogLayer(
   @JsonGetter("blockNumber")
   public Long getBlockNumberValue() {
     return blockNumber.orElse(null);
+  }
+
+  @JsonGetter("timestamp")
+  public Long getTimestampValue() {
+    return timestamp.orElse(null);
   }
 
   @JsonGetter("zkTraceComparisonFeatures")

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -296,14 +296,6 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     // optionally write block number
     layer.getBlockNumber().ifPresent(output::writeLongScalar);
 
-    if (layer instanceof PluginTrieLogLayer ptl) {
-      if (ptl.getTimestamp().isPresent() && layer.getBlockNumber().isEmpty()) {
-        throw new IllegalStateException("blockNumber must be present when timestamp is set");
-      }
-      // optionally write block timestamp
-      ptl.getTimestamp().ifPresent(output::writeLongScalar);
-    }
-
     for (final Address address : addresses) {
       output.startList(); // this change
       output.writeBytes(address.getBytes());
@@ -349,9 +341,19 @@ public class ZkTrieLogFactory implements TrieLogFactory {
       output.endList(); // this change
     }
 
-    // optionally write zkTraceComparisonFeature
-    if (includeMetadata && layer instanceof PluginTrieLogLayer pluginLayer) {
-      pluginLayer.zkTraceComparisonFeature().ifPresent(output::writeInt);
+    if (layer instanceof PluginTrieLogLayer pluginLayer) {
+      boolean hasTimestamp = pluginLayer.getTimestamp().isPresent();
+      // optionally write zkTraceComparisonFeature
+      if (includeMetadata || hasTimestamp) {
+        // when timestamp is present, always write zkCompare to preserve positional order
+        if (hasTimestamp) {
+          output.writeInt(pluginLayer.zkTraceComparisonFeature().orElse(0));
+        } else {
+          pluginLayer.zkTraceComparisonFeature().ifPresent(output::writeInt);
+        }
+      }
+      // always write timestamp when present (appended after zkCompare)
+      pluginLayer.getTimestamp().ifPresent(output::writeLongScalar);
     }
     output.endList(); // container
   }
@@ -383,25 +385,22 @@ public class ZkTrieLogFactory implements TrieLogFactory {
             .filter(isPresent -> isPresent)
             .map(__ -> input.readLongScalar());
 
-    // timestamp is optional, always present when blockNumber is set
-    Optional<Long> timestamp =
-        blockNumber.flatMap(
-            __ ->
-                Optional.of(!input.nextIsList())
-                    .filter(isPresent -> isPresent)
-                    .map(___ -> input.readLongScalar()));
-
     while (!input.isEndOfCurrentList() && input.nextIsList()) {
       input.enterList();
       readAddressChange(input, accounts, code, storage);
       input.leaveListLenient();
     }
 
-    // zkTraceComparisonFeature is optional (read as last element in container, before leaving)
+    // trailing metadata: zkTraceComparisonFeature is optional, followed by optional timestamp
     Optional<Integer> zkTraceComparisonFeature =
         Optional.of(!input.isEndOfCurrentList())
             .filter(isPresent -> isPresent)
             .map(__ -> input.readInt());
+
+    Optional<Long> timestamp =
+        Optional.of(!input.isEndOfCurrentList())
+            .filter(isPresent -> isPresent)
+            .map(__ -> input.readLongScalar());
 
     input.leaveListLenient();
 

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -297,8 +297,8 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     layer.getBlockNumber().ifPresent(output::writeLongScalar);
 
     if (layer instanceof PluginTrieLogLayer ptl) {
-      if (layer.getBlockNumber().isPresent() && ptl.getTimestamp().isEmpty()) {
-        throw new IllegalStateException("timestamp must be present when blockNumber is set");
+      if (ptl.getTimestamp().isPresent() && layer.getBlockNumber().isEmpty()) {
+        throw new IllegalStateException("blockNumber must be present when timestamp is set");
       }
       // optionally write block timestamp
       ptl.getTimestamp().ifPresent(output::writeLongScalar);
@@ -385,12 +385,11 @@ public class ZkTrieLogFactory implements TrieLogFactory {
 
     // timestamp is optional, always present when blockNumber is set
     Optional<Long> timestamp =
-        blockNumber
-            .flatMap(
-                __ ->
-                    Optional.of(!input.nextIsList())
-                        .filter(isPresent -> isPresent)
-                        .map(___ -> input.readLongScalar()));
+        blockNumber.flatMap(
+            __ ->
+                Optional.of(!input.nextIsList())
+                    .filter(isPresent -> isPresent)
+                    .map(___ -> input.readLongScalar()));
 
     while (!input.isEndOfCurrentList() && input.nextIsList()) {
       input.enterList();

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -104,6 +104,7 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     return new PluginTrieLogLayer(
         blockHeader.getBlockHash(),
         Optional.of(blockHeader.getNumber()),
+        Optional.of(blockHeader.getTimestamp()),
         (Map<Address, LogTuple<AccountValue>>) accountsToUpdate,
         (Map<Address, LogTuple<Bytes>>) codeToUpdate,
         (Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>>) storageToUpdate,
@@ -294,6 +295,12 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     output.writeBytes(layer.getBlockHash().getBytes());
     // optionally write block number
     layer.getBlockNumber().ifPresent(output::writeLongScalar);
+
+    if (layer instanceof PluginTrieLogLayer ptl) {
+      // optionally write block timestamp
+      ptl.getTimestamp().ifPresent(output::writeLongScalar);
+    }
+
     for (final Address address : addresses) {
       output.startList(); // this change
       output.writeBytes(address.getBytes());
@@ -373,6 +380,12 @@ public class ZkTrieLogFactory implements TrieLogFactory {
             .filter(isPresent -> isPresent)
             .map(__ -> input.readLongScalar());
 
+    // timestamp is optional
+    Optional<Long> timestamp =
+        Optional.of(!input.nextIsList())
+            .filter(isPresent -> isPresent)
+            .map(__ -> input.readLongScalar());
+
     while (!input.isEndOfCurrentList() && input.nextIsList()) {
       input.enterList();
       final Address address = Address.readFrom(input);
@@ -438,7 +451,7 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     input.leaveListLenient();
 
     return new PluginTrieLogLayer(
-        blockHash, blockNumber, accounts, code, storage, true, zkTraceComparisonFeature);
+        blockHash, blockNumber, timestamp, accounts, code, storage, true, zkTraceComparisonFeature);
   }
 
   protected static <T> T nullOrValue(final RLPInput input, final Function<RLPInput, T> reader) {

--- a/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
+++ b/src/main/java/net/consensys/shomei/trielog/ZkTrieLogFactory.java
@@ -297,6 +297,9 @@ public class ZkTrieLogFactory implements TrieLogFactory {
     layer.getBlockNumber().ifPresent(output::writeLongScalar);
 
     if (layer instanceof PluginTrieLogLayer ptl) {
+      if (layer.getBlockNumber().isPresent() && ptl.getTimestamp().isEmpty()) {
+        throw new IllegalStateException("timestamp must be present when blockNumber is set");
+      }
       // optionally write block timestamp
       ptl.getTimestamp().ifPresent(output::writeLongScalar);
     }
@@ -380,65 +383,18 @@ public class ZkTrieLogFactory implements TrieLogFactory {
             .filter(isPresent -> isPresent)
             .map(__ -> input.readLongScalar());
 
-    // timestamp is optional
+    // timestamp is optional, always present when blockNumber is set
     Optional<Long> timestamp =
-        Optional.of(!input.nextIsList())
-            .filter(isPresent -> isPresent)
-            .map(__ -> input.readLongScalar());
+        blockNumber
+            .flatMap(
+                __ ->
+                    Optional.of(!input.nextIsList())
+                        .filter(isPresent -> isPresent)
+                        .map(___ -> input.readLongScalar()));
 
     while (!input.isEndOfCurrentList() && input.nextIsList()) {
       input.enterList();
-      final Address address = Address.readFrom(input);
-
-      if (input.nextIsNull()) {
-        input.skipNext();
-      } else {
-        input.enterList();
-        final Bytes oldCode = nullOrValue(input, RLPInput::readBytes);
-        final Bytes newCode = nullOrValue(input, RLPInput::readBytes);
-        final boolean isCleared = getOptionalIsCleared(input);
-        input.leaveList();
-        code.put(address, new TrieLogValue<>(oldCode, newCode, isCleared));
-      }
-
-      if (input.nextIsNull()) {
-        input.skipNext();
-      } else {
-        input.enterList();
-        final AccountValue oldValue = nullOrValue(input, ZkAccountValue::readFrom);
-        final AccountValue newValue = nullOrValue(input, ZkAccountValue::readFrom);
-        final boolean isCleared = getOptionalIsCleared(input);
-        input.leaveList();
-        accounts.put(address, new TrieLogValue<>(oldValue, newValue, isCleared));
-      }
-
-      if (input.nextIsNull()) {
-        input.skipNext();
-      } else {
-        final Map<StorageSlotKey, LogTuple<UInt256>> storageChanges = new TreeMap<>();
-        input.enterList();
-        while (!input.isEndOfCurrentList()) {
-          int storageElementlistSize = input.enterList();
-
-          final Hash slotHash = Hash.wrap(input.readBytes32());
-          final UInt256 oldValue = nullOrValue(input, RLPInput::readUInt256Scalar);
-          final UInt256 newValue = nullOrValue(input, RLPInput::readUInt256Scalar);
-          final boolean isCleared = getOptionalIsCleared(input);
-          final Optional<UInt256> slotKey =
-              Optional.of(storageElementlistSize)
-                  .filter(listSize -> listSize == 5)
-                  .map(__ -> input.readUInt256Scalar())
-                  .or(Optional::empty);
-
-          final StorageSlotKey storageSlotKey = new StorageSlotKey(slotHash, slotKey);
-
-          storageChanges.put(storageSlotKey, new TrieLogValue<>(oldValue, newValue, isCleared));
-          input.leaveList();
-        }
-        input.leaveList();
-        storage.put(address, storageChanges);
-      }
-      // lenient leave list for forward compatible additions.
+      readAddressChange(input, accounts, code, storage);
       input.leaveListLenient();
     }
 
@@ -452,6 +408,63 @@ public class ZkTrieLogFactory implements TrieLogFactory {
 
     return new PluginTrieLogLayer(
         blockHash, blockNumber, timestamp, accounts, code, storage, true, zkTraceComparisonFeature);
+  }
+
+  private static void readAddressChange(
+      final RLPInput input,
+      final Map<Address, LogTuple<AccountValue>> accounts,
+      final Map<Address, LogTuple<Bytes>> code,
+      final Map<Address, Map<StorageSlotKey, LogTuple<UInt256>>> storage) {
+    final Address address = Address.readFrom(input);
+
+    if (input.nextIsNull()) {
+      input.skipNext();
+    } else {
+      input.enterList();
+      final Bytes oldCode = nullOrValue(input, RLPInput::readBytes);
+      final Bytes newCode = nullOrValue(input, RLPInput::readBytes);
+      final boolean isCleared = getOptionalIsCleared(input);
+      input.leaveList();
+      code.put(address, new TrieLogValue<>(oldCode, newCode, isCleared));
+    }
+
+    if (input.nextIsNull()) {
+      input.skipNext();
+    } else {
+      input.enterList();
+      final AccountValue oldValue = nullOrValue(input, ZkAccountValue::readFrom);
+      final AccountValue newValue = nullOrValue(input, ZkAccountValue::readFrom);
+      final boolean isCleared = getOptionalIsCleared(input);
+      input.leaveList();
+      accounts.put(address, new TrieLogValue<>(oldValue, newValue, isCleared));
+    }
+
+    if (input.nextIsNull()) {
+      input.skipNext();
+    } else {
+      final Map<StorageSlotKey, LogTuple<UInt256>> storageChanges = new TreeMap<>();
+      input.enterList();
+      while (!input.isEndOfCurrentList()) {
+        int storageElementlistSize = input.enterList();
+
+        final Hash slotHash = Hash.wrap(input.readBytes32());
+        final UInt256 oldValue = nullOrValue(input, RLPInput::readUInt256Scalar);
+        final UInt256 newValue = nullOrValue(input, RLPInput::readUInt256Scalar);
+        final boolean isCleared = getOptionalIsCleared(input);
+        final Optional<UInt256> slotKey =
+            Optional.of(storageElementlistSize)
+                .filter(listSize -> listSize == 5)
+                .map(__ -> input.readUInt256Scalar())
+                .or(Optional::empty);
+
+        final StorageSlotKey storageSlotKey = new StorageSlotKey(slotHash, slotKey);
+
+        storageChanges.put(storageSlotKey, new TrieLogValue<>(oldValue, newValue, isCleared));
+        input.leaveList();
+      }
+      input.leaveList();
+      storage.put(address, storageChanges);
+    }
   }
 
   protected static <T> T nullOrValue(final RLPInput input, final Function<RLPInput, T> reader) {

--- a/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogMetadataTests.java
+++ b/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogMetadataTests.java
@@ -117,7 +117,14 @@ public class GetShomeiTrieLogMetadataTests {
 
     PluginTrieLogLayer mockLayer =
         new PluginTrieLogLayer(
-            Hash.ZERO, Optional.of(123L), accounts, code, storage, true, Optional.of(24));
+            Hash.ZERO,
+            Optional.of(123L),
+            Optional.of(1L),
+            accounts,
+            code,
+            storage,
+            true,
+            Optional.of(24));
 
     // mock single log response
     when(mockProvider.getTrieLogLayer(123)).thenReturn(Optional.of(mockLayer));
@@ -156,6 +163,7 @@ public class GetShomeiTrieLogMetadataTests {
             Hash.fromHexString(
                 "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
             Optional.of(456L),
+            Optional.of(1L),
             Map.of(),
             Map.of(),
             Map.of(),

--- a/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogMetadataTests.java
+++ b/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogMetadataTests.java
@@ -146,6 +146,7 @@ public class GetShomeiTrieLogMetadataTests {
           assertThat(res.getString("blockHash"))
               .isEqualTo("0x0000000000000000000000000000000000000000000000000000000000000000");
           assertThat(res.getLong("blockNumber")).isEqualTo(123L);
+          assertThat(res.getLong("timestamp")).isEqualTo(1L);
           assertThat(res.getJsonArray("zkTraceComparisonFeatures"))
               .containsExactlyInAnyOrder("DECORATE_FROM_HUB", "FILTER_FROM_HUB");
           assertThat(res.getInteger("zkTraceComparisonFeatureMask")).isEqualTo(24);

--- a/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogsTests.java
+++ b/src/test/java/net/consensys/shomei/rpc/GetShomeiTrieLogsTests.java
@@ -57,7 +57,14 @@ public class GetShomeiTrieLogsTests {
 
   PluginTrieLogLayer mockLayer =
       new PluginTrieLogLayer(
-          Hash.ZERO, Optional.of(0L), Map.of(), Map.of(), Map.of(), true, Optional.empty());
+          Hash.ZERO,
+          Optional.of(0L),
+          Optional.of(1L),
+          Map.of(),
+          Map.of(),
+          Map.of(),
+          true,
+          Optional.empty());
 
   MockJsonRpcHttpVerticle verticle;
   WebClient client;

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -65,6 +65,7 @@ public class ZkTrieLogFactoryTests {
       new PluginTrieLogLayer(
           Hash.ZERO,
           Optional.of(1L),
+          Optional.of(1L),
           new HashMap<>(),
           new HashMap<>(),
           new HashMap<>(),
@@ -99,7 +100,13 @@ public class ZkTrieLogFactoryTests {
     assertDoesNotThrow(
         () -> {
           new PluginTrieLogLayer(
-              Hash.ZERO, Optional.of(1L), new HashMap<>(), new HashMap<>(), new HashMap<>(), true);
+              Hash.ZERO,
+              Optional.of(1L),
+              Optional.of(1L),
+              new HashMap<>(),
+              new HashMap<>(),
+              new HashMap<>(),
+              true);
         });
   }
 

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
@@ -45,6 +46,8 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.datatypes.StorageSlotKey;
 import org.hyperledger.besu.datatypes.Wei;
+import org.hyperledger.besu.ethereum.rlp.BytesValueRLPOutput;
+import org.hyperledger.besu.ethereum.rlp.RLPOutput;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.BonsaiAccount;
 import org.hyperledger.besu.ethereum.trie.pathbased.bonsai.cache.CodeCache;
 import org.hyperledger.besu.ethereum.trie.pathbased.common.PathBasedValue;
@@ -578,5 +581,127 @@ public class ZkTrieLogFactoryTests {
     assertThat(trielog.getAccountChanges().containsKey(directAddress)).isTrue();
     assertThat(trielog.getAccountChanges().get(directAddress).getPrior()).isEqualTo(directBonsai);
     assertThat(trielog.getAccountChanges().get(directAddress).getUpdated()).isEqualTo(directBonsai);
+  }
+
+  @Test
+  void testDeserializeOldFormatWithAddressChanges() {
+    // Simulate old RLP format: [blockHash, blockNumber, [addressChanges...], zkCompare]
+    // (no timestamp field)
+    byte[] oldRlp = serializeOldFormat(trieLogFixture, true);
+
+    TrieLogFactory factory = new ZkTrieLogFactory(testCtx);
+    PluginTrieLogLayer deserialized = (PluginTrieLogLayer) factory.deserialize(oldRlp);
+
+    assertThat(deserialized.getBlockHash()).isEqualTo(Hash.ZERO);
+    assertThat(deserialized.getBlockNumber()).isPresent();
+    assertThat(deserialized.getBlockNumber().get()).isEqualTo(1L);
+    assertThat(deserialized.getTimestamp()).isEmpty();
+    assertThat(deserialized.getAccountChanges()).isEqualTo(trieLogFixture.getAccountChanges());
+    assertThat(deserialized.getCodeChanges()).isEqualTo(trieLogFixture.getCodeChanges());
+    assertThat(deserialized.getStorageChanges()).isEqualTo(trieLogFixture.getStorageChanges());
+  }
+
+  @Test
+  void testDeserializeOldFormatNoAddressChangesWithZkCompare() {
+    // Edge case: old format with blockNumber, no address changes, but zkCompare trailing scalar.
+    // Without list-wrapping, the deserializer would consume zkCompare as timestamp.
+    PluginTrieLogLayer emptyWithZkCompare =
+        new PluginTrieLogLayer(
+            Hash.ZERO,
+            Optional.of(42L),
+            new HashMap<>(),
+            new HashMap<>(),
+            new HashMap<>(),
+            true,
+            Optional.of(15));
+
+    byte[] oldRlp = serializeOldFormat(emptyWithZkCompare, true);
+
+    TrieLogFactory factory = new ZkTrieLogFactory(testCtx);
+    PluginTrieLogLayer deserialized = (PluginTrieLogLayer) factory.deserialize(oldRlp);
+
+    assertThat(deserialized.getBlockNumber()).isPresent();
+    assertThat(deserialized.getBlockNumber().get()).isEqualTo(42L);
+    assertThat(deserialized.getTimestamp()).isEmpty();
+    assertThat(deserialized.zkTraceComparisonFeature()).isPresent();
+    assertThat(deserialized.zkTraceComparisonFeature().get()).isEqualTo(15);
+  }
+
+  @Test
+  void testDeserializeOldFormatMinimal() {
+    // Old format with only blockHash and blockNumber, no changes, no zkCompare
+    PluginTrieLogLayer minimal =
+        new PluginTrieLogLayer(
+            Hash.ZERO, Optional.of(1L), new HashMap<>(), new HashMap<>(), new HashMap<>(), true);
+
+    byte[] oldRlp = serializeOldFormat(minimal, false);
+
+    TrieLogFactory factory = new ZkTrieLogFactory(testCtx);
+    PluginTrieLogLayer deserialized = (PluginTrieLogLayer) factory.deserialize(oldRlp);
+
+    assertThat(deserialized.getBlockNumber()).isPresent();
+    assertThat(deserialized.getBlockNumber().get()).isEqualTo(1L);
+    assertThat(deserialized.getTimestamp()).isEmpty();
+    assertThat(deserialized.zkTraceComparisonFeature()).isEmpty();
+  }
+
+  /**
+   * Produces RLP in the old format (before timestamp was added): [blockHash, blockNumber?,
+   * [addressChanges]*, zkCompare?]
+   */
+  private static byte[] serializeOldFormat(PluginTrieLogLayer layer, boolean includeMetadata) {
+    final BytesValueRLPOutput output = new BytesValueRLPOutput();
+    final var addresses = new TreeSet<Address>();
+    addresses.addAll(layer.getAccountChanges().keySet());
+    addresses.addAll(layer.getCodeChanges().keySet());
+    addresses.addAll(layer.getStorageChanges().keySet());
+
+    output.startList();
+    output.writeBytes(layer.getBlockHash().getBytes());
+    layer.getBlockNumber().ifPresent(output::writeLongScalar);
+    // NOTE: no timestamp — this is the old format
+
+    for (final Address address : addresses) {
+      output.startList();
+      output.writeBytes(address.getBytes());
+
+      final LogTuple<Bytes> codeChange = layer.getCodeChanges().get(address);
+      if (codeChange == null || codeChange.isUnchanged()) {
+        output.writeNull();
+      } else {
+        ZkTrieLogFactory.writeRlp(codeChange, output, RLPOutput::writeBytes);
+      }
+
+      final LogTuple<AccountValue> accountChange = layer.getAccountChanges().get(address);
+      if (accountChange == null) {
+        output.writeNull();
+      } else {
+        ZkTrieLogFactory.writeRlp(accountChange, output, (o, sta) -> sta.writeTo(o));
+      }
+
+      final var storageChanges = layer.getStorageChanges().get(address);
+      if (storageChanges == null || storageChanges.isEmpty()) {
+        output.writeNull();
+      } else {
+        output.startList();
+        for (final var storageEntry : storageChanges.entrySet()) {
+          output.startList();
+          output.writeBytes(storageEntry.getKey().getSlotHash().getBytes());
+          ZkTrieLogFactory.writeInnerRlp(
+              storageEntry.getValue(), output, RLPOutput::writeUInt256Scalar);
+          storageEntry.getKey().getSlotKey().ifPresent(output::writeUInt256Scalar);
+          output.endList();
+        }
+        output.endList();
+      }
+
+      output.endList();
+    }
+
+    if (includeMetadata) {
+      layer.zkTraceComparisonFeature().ifPresent(output::writeInt);
+    }
+    output.endList();
+    return output.encoded().toArrayUnsafe();
   }
 }

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogFactoryTests.java
@@ -97,16 +97,22 @@ public class ZkTrieLogFactoryTests {
 
   @Test
   public void assertPluginTrieLogLayerApiBackwardsCompatibility() {
+    // Verify old constructor signatures (without timestamp) still compile and work
+    assertDoesNotThrow(
+        () -> {
+          new PluginTrieLogLayer(
+              Hash.ZERO, Optional.of(1L), new HashMap<>(), new HashMap<>(), new HashMap<>(), true);
+        });
     assertDoesNotThrow(
         () -> {
           new PluginTrieLogLayer(
               Hash.ZERO,
               Optional.of(1L),
-              Optional.of(1L),
               new HashMap<>(),
               new HashMap<>(),
               new HashMap<>(),
-              true);
+              true,
+              Optional.of(1));
         });
   }
 
@@ -118,9 +124,15 @@ public class ZkTrieLogFactoryTests {
     TrieLog layer = factory.deserialize(rlp);
     assertThat(layer).isEqualTo(trieLogFixture);
 
+    // equals() ignores metadata fields — verify timestamp explicitly
+    assertThat(layer).isInstanceOf(PluginTrieLogLayer.class);
+    PluginTrieLogLayer deserialized = (PluginTrieLogLayer) layer;
+    assertThat(deserialized.getTimestamp()).isPresent();
+    assertThat(deserialized.getTimestamp().get()).isEqualTo(1L);
+
     assertThat(
             layer.getStorageChanges().get(Address.ZERO).keySet().stream()
-                .map(k -> k.getSlotKey())
+                .map(StorageSlotKey::getSlotKey)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .anyMatch(key -> key.equals(UInt256.ZERO)))
@@ -414,14 +426,14 @@ public class ZkTrieLogFactoryTests {
     // Assert address1 is partially filtered, with only slot3 remaining:
     assertTrue(result.containsKey(address1));
     Map<StorageSlotKey, ? extends LogTuple<UInt256>> filteredSlots = result.get(address1);
-    assertTrue(filteredSlots.size() == 1);
+    assertEquals(1, filteredSlots.size());
     assertTrue(filteredSlots.containsKey(slot3));
     assertEquals(value3, filteredSlots.get(slot3));
 
     // Assert address2 storage is not filtered at all
     assertTrue(result.containsKey(address2));
     Map<StorageSlotKey, ? extends LogTuple<UInt256>> filteredSlots2 = result.get(address2);
-    assertTrue(filteredSlots2.size() == 1);
+    assertEquals(1, filteredSlots2.size());
     assertTrue(filteredSlots2.containsKey(slot2));
     assertEquals(value2, filteredSlots2.get(slot2));
 

--- a/src/test/java/net/consensys/shomei/trielog/ZkTrieLogObserverTests.java
+++ b/src/test/java/net/consensys/shomei/trielog/ZkTrieLogObserverTests.java
@@ -59,6 +59,7 @@ public class ZkTrieLogObserverTests {
       new PluginTrieLogLayer(
           Hash.ZERO,
           Optional.of(1337L),
+          Optional.of(1L),
           Map.of(
               Address.ZERO,
               new TrieLogValue<>(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes trie log wire/serialization format by appending a new optional `timestamp` field and adjusting metadata ordering, which could break interoperability or decoding if any external consumers assume the old layout.
> 
> **Overview**
> Adds optional block `timestamp` to `PluginTrieLogLayer` and exposes it via JSON metadata.
> 
> Updates `ZkTrieLogFactory` to populate timestamp from the `BlockHeader` and to extend RLP serialization/deserialization: timestamp is appended after the zk-compare mask, and serialization ensures a zk-compare scalar is written when needed to preserve positional order. Refactors address-change decoding into a helper and expands tests to cover backward compatibility with the pre-timestamp RLP formats and RPC metadata responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b836b26404516b933a520582f35af6d5c405df2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->