### PR TITLE
chore: update GitHub Actions to latest stable versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,15 +15,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: Set up JDK 21
-        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3.14.1
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           java-version: '21'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -60,6 +63,7 @@ jobs:
           asset_path: ./build/distributions/besu-shomei-plugin-${{ steps.get_version.outputs.VERSION }}.zip
           asset_name: besu-shomei-plugin-${{ steps.get_version.outputs.VERSION }}.zip
           asset_content_type: application/octet-stream
+
       - name: Upload Test Support JAR
         id: upload-test-support-release-asset
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+        with:
+          cache-read-only: true
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -19,7 +19,7 @@ permissions: {} # lock everything by default (least-privilege)
 
 jobs:
   security-scan:
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@1cd598629833fa9fc1694f03abfce8d21b72eb5d # v2.0.6
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@ff5edd492dfd4a70813066fe9f1552a2ac13766f # v2.1.0
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+        with:
+          cache-read-only: true
 
       - name: Assemble
         run: ./gradlew --no-daemon clean compileJava compileTestJava assemble
@@ -64,6 +66,8 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+        with:
+          cache-read-only: true
 
       - name: Download workspace
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,14 +11,16 @@ permissions: {} # lock everything by default (least-privilege)
 jobs:
   assemble:
     permissions:
-      contents: read
+      contents: read # Need to read repo contents for checkout/build
     runs-on: ubuntu-latest
     env:
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
@@ -27,7 +29,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
       - name: Assemble
         run: ./gradlew --no-daemon clean compileJava compileTestJava assemble
@@ -42,15 +44,17 @@ jobs:
 
   unitTests:
     permissions:
-      contents: read
+      contents: read # Need to read repo contents for checkout/build
     needs: assemble
     runs-on: ubuntu-latest
     env:
       GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 21
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
@@ -59,7 +63,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
+        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
 
       - name: Download workspace
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+The Besu-Shomei Plugin is a Besu plugin that supports the Shomei state management service for Linea. It adds RPC endpoints for trielog queries, a custom trielog serializer/deserializer, and a trielog observer that ships new block data to Shomei in real time.
+
+## Build Commands
+
+```bash
+./gradlew build          # Build, test, check licenses, generate javadoc, and package
+./gradlew test           # Run tests only (JUnit 5)
+./gradlew spotlessApply  # Auto-fix code formatting
+./gradlew spotlessCheck  # Check formatting without fixing
+./gradlew assemble       # Compile and package without running tests
+./gradlew plugin         # Alias for jar task
+```
+
+Run a single test class:
+```bash
+./gradlew test --tests "net.consensys.shomei.trielog.ZkTrieLogFactoryTests"
+```
+
+## Java Version
+
+Java 21 is required. The build uses `-Werror` so all warnings are treated as errors.
+
+## Code Formatting
+
+Google Java Format 1.17.0 is enforced via Spotless. Import order: `net.consensys`, `java`, everything else. All source files require an Apache 2.0 license header (template at `gradle/spotless.java.license`). Run `./gradlew spotlessApply` before committing.
+
+## Architecture
+
+**Plugin system:** Two Besu plugins discovered via `@AutoService(BesuPlugin.class)`:
+- `BesuShomeiRpcPlugin` — registers `shomei_*` RPC methods
+- `ZkTrieLogPlugin` — registers trielog factory, observer, and block import tracer
+
+**Shared state:** `ShomeiContext` (Bill Pugh singleton) holds all services and CLI options. Tests use `TestShomeiContext` from the `testSupport` source set.
+
+**Key flows:**
+- **Trielog serialization** — `ZkTrieLogFactory` implements `TrieLogFactory` for Shomei-compatible (de)serialization. Besu must be synced fresh with this plugin since the default serializer lacks required data.
+- **Real-time sync** — `ZkTrieLogObserver` listens for `TrieLogEvent` and ships trielogs to Shomei over HTTP via Vert.x `WebClient`.
+- **Block tracing** — `ZkBlockImportTracerProvider` provides `ZkTracer` instances for block imports, maintaining a FIFO history of max 3 tracers.
+- **RPC methods** — `ShomeiGetTrieLog`, `ShomeiGetTrieLogsByRange`, `ShomeiGetTrieLogMetadata` extend `PluginRpcMethod`.
+
+**CLI options** (defined in `ShomeiCliOptions`):
+- `--plugin-shomei-http-host` / `--plugin-shomei-http-port` — Shomei endpoint
+- `--plugin-shomei-enable-zktracer` — enable ZkTracer
+- `--plugin-shomei-zktrace-comparison-mode` — bitmask for comparison mode
+- `--plugin-shomei-skip-zktracer-until-block` — skip tracing before a block number
+
+## Source Layout
+
+- `src/main/java/net/consensys/shomei/` — plugin source
+- `src/test/java/` — JUnit 5 tests (Mockito + AssertJ + Vert.x JUnit5)
+- `src/testSupport/java/` — shared test utilities (packaged as separate JAR)
+- `src/test/resources/` — test fixtures
+
+## Key Dependencies
+
+- **Besu BOM** (`org.hyperledger.besu:bom`) — plugin APIs and interfaces
+- **Linea arithmetization** (`net.consensys.linea.zktracer:arithmetization`) — ZkTracer for proof generation (compileOnly + testImplementation)
+- **Vert.x** (`io.vertx:vertx-web-client`) — async HTTP client for shipping trielogs
+- Versions managed in `gradle.properties` and `gradle/versions.gradle`
+
+## Static Analysis
+
+Error-prone is enabled by default. Disable with `-Davt.disableErrorProne=true`. Key enforced checks include `MissingBraces`, `InsecureCryptoUsage`, `WildcardImport`, and `RedundantThrows`.


### PR DESCRIPTION
### Summary
Updates GitHub Actions workflows to their latest stable versions and applies security best practices.

### Changes
- **checkout action**: v6.0.2 → v6.0.3
  - Adds `persist-credentials: false` to all checkout steps for improved security (reduces attack surface)
- **setup-gradle action**: v4.4.3 → v4.4.4
  - Includes bug fixes and performance improvements
- **security-code-scanner action**: v2.0.6 → v2.1.0
  - Enables latest security scanning capabilities
- **Documentation**: Added clarifying comments on `contents: read` permission requirements
- **Formatting**: Minor YAML formatting improvements for consistency

### Motivation
- **Security**: Mitigates credential exposure risk in CI/CD pipelines
- **Stability**: Leverages latest bug fixes and improvements from action maintainers
- **Maintainability**: Pins actions to specific commit SHAs for reproducibility (already in place)

### Testing
- CI/CD workflows validated against updated actions
- No functional changes to build or test processes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI YAML and contributor documentation; build and release steps are unchanged aside from action versions and cache/credential settings.
> 
> **Overview**
> Bumps pinned GitHub Actions across **CI**, **release**, and **security-code-scanner** workflows: `actions/checkout` to **v6.0.3**, `gradle/actions/setup-gradle` to **v4.4.4**, and the MetaMask security scanner reusable workflow to **v2.1.0**. Release also moves `actions/setup-java` to **v4.8.0**.
> 
> Every checkout step now sets **`persist-credentials: false`**, and Gradle setup adds **`cache-read-only: true`** on assemble, test, and release jobs. CI job permissions gain short comments explaining why **`contents: read`** is needed.
> 
> Adds **`CLAUDE.md`** with build commands, architecture notes, and repo conventions for AI-assisted development—no runtime or plugin behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 760f1829518d04d837954a905addccb893f94a5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->