### PR TITLE
ci: build CodeQL analysis with JDK 25

### DIFF
--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -44,7 +44,7 @@ jobs:
             "language": "java-kotlin",
             "build_mode": "manual",
             "build_command": "./gradlew build",
-            "version": "21",
+            "version": "25",
             "distribution": "temurin"
           }
         ]


### PR DESCRIPTION
## Summary

The security code scanner's CodeQL analysis job was failing to build with:

```
Execution failed for task ':compileJava'.
> Java compilation initialization error
    error: invalid source release: 25
```

The project now targets Java 25 (`sourceCompatibility`/`targetCompatibility` in
`build.gradle`), and the CI and release workflows already build with JDK 25.
However, the CodeQL analysis job still specified JDK 21 in its `languages-config`,
so `./gradlew build` ran under Java 21 and could not compile a release-25 source set.

## Change

Bump the CodeQL analysis build JDK from 21 to 25 in
`.github/workflows/security-code-scanner.yml`, bringing it in line with the CI
(`workflow.yml`) and release (`release.yml`) workflows.

## Verification

Once merged, the CodeQL analysis job compiles the project successfully instead of
failing during `:compileJava`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only JDK version alignment for the security scanner; no application runtime or security logic changes.
> 
> **Overview**
> Updates the MetaMask security code scanner workflow so CodeQL’s manual `./gradlew build` runs on **JDK 25** instead of **21**, matching the project’s Java 25 `sourceCompatibility`/`targetCompatibility` and other CI/release jobs.
> 
> This fixes CodeQL failing at `:compileJava` with `invalid source release: 25` when the analysis job still compiled under Java 21.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b2f0cffee9bc9d045be2d9dd985dc8dd3b7e97d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->