### PR TITLE
chore: bump GitHub Actions off Node 20 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,18 +15,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Set up JDK 25
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: '25'
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           cache-read-only: true
 

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -19,7 +19,7 @@ permissions: {} # lock everything by default (least-privilege)
 
 jobs:
   security-scan:
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@ff5edd492dfd4a70813066fe9f1552a2ac13766f # v2.1.0
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@becb242930b3cc271c26da0280050db9c157e291 # v2.1.1
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -18,18 +18,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Set up JDK 25
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: 25
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           cache-read-only: true
 
@@ -37,7 +37,7 @@ jobs:
         run: ./gradlew --no-daemon clean compileJava compileTestJava assemble
 
       - name: Upload workspace
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: workspace
           path: |
@@ -54,23 +54,23 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
       - name: Set up JDK 25
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: 25
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           cache-read-only: true
 
       - name: Download workspace
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: workspace
 
@@ -78,7 +78,7 @@ jobs:
         run: ./gradlew --no-daemon build
 
       - name: Store distribution artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: distributions
           path: build/distributions


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout`, `actions/setup-java`, `gradle/actions/setup-gradle`, `actions/upload-artifact`, `actions/download-artifact`, and the `MetaMask/action-security-code-scanner` reusable workflow to their latest `node24`-based releases, clearing the "Node.js 20 is deprecated" CI annotations.
- No `with:`/`env:` inputs change for any action — same parameters, new pinned SHAs (commit-SHA pinning, per existing convention).
- Deliberately **not** taking the newest major for two actions, since it carries a real behavior/licensing change:
  - `actions/download-artifact` → `v7.0.0` (not `v8.0.1`, which defaults `digest-mismatch` handling to a hard error and moves to ESM)
  - `gradle/actions/setup-gradle` → `v5.0.2` (not `v6.2.0`, which extracts caching into a proprietary, non-MIT-licensed `gradle-actions-caching` component — triggered by our `cache-read-only: true` usage)
- The archived `actions/create-release` / `actions/upload-release-asset` steps in `release.yml` are intentionally untouched — they're deprecated (archived repos) rather than outdated, need a migration instead of a version bump, and are tracked separately.

This supersedes open Dependabot PRs #75 (`setup-java` → 5.4.0) and #83 (`upload-artifact` → 7.0.0) with newer/equivalent versions. It intentionally diverges from Dependabot PRs #79 (`download-artifact` → 8.0.1) and #84 (`gradle/actions` → 6) for the reasons above — worth closing those two with an explanatory comment once this merges, rather than letting Dependabot re-open them.

## Test plan
- [ ] CI (`assemble`, `unitTests`, and the security scanner workflow) passes on this PR
- [ ] Confirm the "Node.js 20 is deprecated" annotations no longer appear in the Actions run summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin updates with no application or secret-handling logic changes; main risk is transient workflow breakage from major action upgrades, mitigated by conservative version choices.
> 
> **Overview**
> Updates pinned action SHAs in **CI**, **release**, and **security scanner** workflows so jobs run on current Node 24–based action releases and clear GitHub’s Node 20 deprecation warnings.
> 
> **`workflow.yml`**, **`release.yml`**: `actions/checkout` → v7.0.0, `actions/setup-java` → v5.5.0, `gradle/actions/setup-gradle` → v5.0.2 (not v6, to avoid proprietary caching). **`workflow.yml`** also bumps `actions/upload-artifact` → v7.0.1 and `actions/download-artifact` → v7.0.0 (not v8, to avoid stricter digest-mismatch defaults).
> 
> **`security-code-scanner.yml`**: MetaMask reusable workflow pin → v2.1.1.
> 
> All `with:` / `env:` inputs are unchanged. Archived `actions/create-release` / `actions/upload-release-asset` steps in `release.yml` are left as-is.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc91de44a7172217a253eca63530551ef2e34fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->