### PR TITLE
Refactor release actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,11 @@ jobs:
           VERSION: ${{ steps.get_version.outputs.VERSION }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
+          cp "./build/libs/besu-shomei-plugin-${VERSION}-test-support.jar" \
+             "./build/libs/besu-shomei-plugin-test-support-${VERSION}.jar"
           gh release create "$TAG_NAME" \
             --title "Release $TAG_NAME" \
             --notes "Draft release of version ${VERSION}." \
             --draft \
             "./build/distributions/besu-shomei-plugin-${VERSION}.zip" \
-            "./build/libs/besu-shomei-plugin-${VERSION}-test-support.jar#besu-shomei-plugin-test-support-${VERSION}.jar"
+            "./build/libs/besu-shomei-plugin-test-support-${VERSION}.jar"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Build with Gradle
         run: ./gradlew build -PreleaseVersion=${{ steps.get_version.outputs.VERSION }}
@@ -44,35 +44,13 @@ jobs:
         run: ./gradlew test
 
       - name: Draft Release
-        id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: 'Draft release of version ${{ steps.get_version.outputs.VERSION }}.'
-          draft: true
-          prerelease: false
-
-      - name: Upload Release Asset
-        id: upload-release-asset
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/distributions/besu-shomei-plugin-${{ steps.get_version.outputs.VERSION }}.zip
-          asset_name: besu-shomei-plugin-${{ steps.get_version.outputs.VERSION }}.zip
-          asset_content_type: application/octet-stream
-
-      - name: Upload Test Support JAR
-        id: upload-test-support-release-asset
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./build/libs/besu-shomei-plugin-${{ steps.get_version.outputs.VERSION }}-test-support.jar
-          asset_name: besu-shomei-plugin-test-support-${{ steps.get_version.outputs.VERSION }}.jar
-          asset_content_type: application/octet-stream
+        run: |
+          VERSION=${{ steps.get_version.outputs.VERSION }}
+          gh release create "${{ github.ref_name }}" \
+            --title "Release ${{ github.ref_name }}" \
+            --notes "Draft release of version ${VERSION}." \
+            --draft \
+            "./build/distributions/besu-shomei-plugin-${VERSION}.zip" \
+            "./build/libs/besu-shomei-plugin-${VERSION}-test-support.jar#besu-shomei-plugin-test-support-${VERSION}.jar"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,9 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Build with Gradle
-        run: ./gradlew build -PreleaseVersion=${{ steps.get_version.outputs.VERSION }}
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+        run: ./gradlew build -PreleaseVersion="$VERSION"
 
       - name: Test with Gradle
         run: ./gradlew test
@@ -46,10 +48,11 @@ jobs:
       - name: Draft Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          TAG_NAME: ${{ github.ref_name }}
         run: |
-          VERSION=${{ steps.get_version.outputs.VERSION }}
-          gh release create "${{ github.ref_name }}" \
-            --title "Release ${{ github.ref_name }}" \
+          gh release create "$TAG_NAME" \
+            --title "Release $TAG_NAME" \
             --notes "Draft release of version ${VERSION}." \
             --draft \
             "./build/distributions/besu-shomei-plugin-${VERSION}.zip" \


### PR DESCRIPTION
## PR Description

Migrate to gh cli in the release workflow as the release actions are no longer supported.


<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/shomei/blob/master/CONTRIBUTING.md -->


## Fixed Issue(s)
addresses issues opened by zizmor 5, 6, and 7

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how release artifacts are published on tag push; a misconfiguration could fail or misname draft releases, but impact is limited to CI release automation.
> 
> **Overview**
> The tag-triggered **release workflow** no longer uses deprecated `actions/create-release` and `actions/upload-release-asset`. Draft releases are created in one step with **`gh release create`**, uploading the distribution zip and test-support JAR together.
> 
> Workflow maintenance updates include writing the tag version to **`$GITHUB_OUTPUT`** instead of `::set-output`, and passing **`VERSION`** via `env` into the Gradle build command.
> 
> Before upload, the test-support artifact is **copied/renamed** so the release asset name stays `besu-shomei-plugin-test-support-${VERSION}.jar`, matching the previous upload step behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 582bf59cbe08c7ea3e51ae6995960ef4779c14a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->